### PR TITLE
refactor(karuta): reorganize data models and implementation structure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,5 +28,4 @@ tools/prompts/*
 *.log
 
 # Temporary ignore files
-# src/utils/__tests__/snapshot-error-utils.test.ts
-
+src/App.tsx

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,622 @@
+# pp-karuta Design Document
+
+## Overview
+
+pp-karutaは、ProtoPediaのプロトタイプデータを活用したカルタゲームアプリケーションです。
+
+## Data Source
+
+### ProtoPedia API v2 and PROMIDAS
+
+- [ProtoPedia API v2 Response型定義](https://raw.githubusercontent.com/F88/protopedia-api-v2-client.js/af40cfdba1908a7a21f0576859b0e1907d337b81/src/types/protopedia-api-v2/response.ts)
+- [PROMIDAS normalizePrototype](https://raw.githubusercontent.com/F88/promidas/dd64e5a20ebe562e35e7eb032326e5d0faf7f315/lib/fetcher/utils/normalize-prototype.ts)
+
+### What is Karuta?
+
+カルタは日本の伝統的なカードゲームです。
+
+#### 道具
+
+- **文字札・読み札(yomifuda)**: 取り札の内容を書いた短い文章が書かれており、読み手が声に出して読む
+- **絵札・取り札(torifuda)**: 読み札の内容を描いた絵と、読み札の文言の頭文字がひらがなで書かれている
+
+伝統的なかるたでは、あいうえお46枚ずつの札があり、一音につき一セットの読み札・取り札が用意されています。
+
+#### 基本ルール
+
+1. 2人以上で行う
+2. 取り札を平面に広げ、取る人に見やすくする
+3. 読み人が読み札を読む
+4. できるだけ早く、読み札に合った取り札を取る(または叩く)
+5. 全ての札がなくなるまで繰り返す
+6. より多くの取り札を取った方の勝ち
+
+参考: [Karuta - Wikipedia](https://en.wikipedia.org/wiki/Karuta)
+
+### PROMIDAS Integration
+
+- [PROMIDAS](https://github.com/F88/promidas)を使用してProtoPedia API v2からプロトタイプデータを取得
+- 取得したプロトタイプを「札(カード)」として使用
+- 100件のプロトタイプをキャッシュし、ゲーム中に利用
+
+## Game Rules
+
+### pp-karuta の基本ルール
+
+伝統的なかるたのルールをProtoPediaのプロトタイプデータに適用します。
+
+#### 札の構成
+
+**YomiFuda(読み札・文字札)**
+
+- ProtoPedia API から取得したプロトタイプの説明文(description)または概要
+- 画面上部に表示される
+- 1枚ずつ順番に表示
+
+**ToriFuda(取り札・絵札)**
+
+- ProtoPedia API から取得したプロトタイプの画像(サムネイル)
+- プロトタイプのタイトル
+- `prototypeId` を持ち、YomiFuda との対応関係を判定できる
+- 複数枚が「Tatami(畳)」エリアに配置される
+
+**札の枚数**
+
+- 伝統的なかるたの46枚制限はなし
+- ProtoPedia API から取得できる範囲で任意の枚数を使用可能
+
+#### ゲームの流れ
+
+##### Phase 0: 入力方式選択 (タイトル画面)
+
+**入力方式選択**
+
+- **Keyboard**: ショートカットキーで操作 (PC環境)
+    - 共通のTatamiエリアを使用
+    - 各プレイヤーに専用のキーバインドを割り当て
+        - Player 1: 1, 2, 3, 4, 5
+        - Player 2: Q, W, E, R, T
+        - Player 3: A, S, D, F, G
+        - Player 4: Z, X, C, V, B
+- **Touch**: タップで操作 (モバイル/タッチ環境)
+    - 各プレイヤーに専用のTatamiエリアを表示
+    - プレイヤーは自分のエリアのみタップ可能
+    - 画面レイアウトはプレイヤー数に応じて分割
+
+**この選択により後続の画面レイアウトが確定する**
+
+##### Phase 1: プレイヤー人数選択
+
+**プレイヤー人数選択**
+
+- 1人〜4人から選択
+- Touchモードの場合、選択した人数により画面分割が決定
+    - 1人: 全画面
+    - 2人: 上下または左右分割
+    - 3-4人: グリッド分割
+
+##### Phase 2: BOX選択
+
+**BOX一覧表示**
+
+- 利用可能なBOXを表示
+- 各BOXには以下の仕様が定義されている:
+    - データフィルタ条件 (タグ、年代など)
+    - 札の枚数
+    - 難易度設定
+    - タイムリミット (オプション)
+
+**BOX選択**
+
+- プレイヤーが任意のBOXを選択
+- 選択されたBOX仕様に基づいてYomiFuda/ToriFudaを生成
+
+##### Phase 3: ゲーム初期化
+
+**データ準備**
+
+1. PROMIDASから選択されたBOX仕様に合致するPrototypeDataを取得
+2. PrototypeDataからYomiFuda と ToriFudaを生成
+    - 両者は `prototypeId` で対応関係を持つ
+3. YomiFudaの順序をシャッフル (またはBOX仕様に従う)
+4. **ToriFuda Stack の初期化**
+    - すべてのToriFudaをシャッフル
+    - 配列としてStackを保持 (例: `toriFudaStack = shuffle(allToriFudas)`)
+5. **初期Tatami配置**
+    - Stackから最初の5枚をpopしてTatamiに配置
+
+**ゲーム状態初期化**
+
+- 現在のRace = 1
+- 総Race数 = YomiFudaの枚数
+- 各プレイヤーのMochiFuda = []
+- ToriFuda Stack (残りのToriFuda)
+- Tatami (表示中の5枚のToriFuda)
+- タイマー開始
+
+##### Phase 4: ゲームプレイ (Race進行)
+
+\*_1 Game = (YomiFuda 数 = ToriFuda 数) _ Race
+
+**1 Race = YomiFudaが表示されてから対応するToriFudaが取られるまで**
+
+**Race開始**
+
+1. 現在のYomiFudaを表示
+2. Tatamiには既に配置済みのToriFudaが表示されている
+    - Tatami上のToriFudaの中に正解(currentYomiFudaに対応するToriFuda)が含まれる
+    - 正解が含まれない場合: 現在のYomiFudaはスキップ (該当札なし)
+    - 各ToriFudaに番号を表示 (1-5, またはTatami上の枚数に応じて)
+
+**プレイヤーアクション (早い者勝ち)**
+
+- 全プレイヤーが同時に入力可能
+- Keyboard入力:
+    - 共通のTatamiに対して各プレイヤーが割り当てられたキーで入力
+- Touch入力:
+    - 各プレイヤー専用のTatamiエリア (同じToriFudaを表示)
+    - 自分のエリアをタップして選択
+
+**判定**
+
+- 最初に正解のToriFudaを選択したプレイヤーが獲得
+- **正解時**:
+    1. そのプレイヤーのMochiFudaに追加
+    2. 正解のToriFudaをTatamiから除去
+    3. **Stackに札が残っている場合**: Stack.shift() で1枚取り出してTatamiに追加
+    4. **Stackが空の場合**: Tatamiに追加せず (Tatamiの札は徐々に減っていく)
+    5. スコア加算
+    6. 次のRaceへ進む
+- **不正解時**:
+    1. ペナルティ (スコア減算など)
+    2. そのプレイヤーは引き続き選択可能
+    3. 誰かが正解するまで継続
+
+**Race終了条件**
+
+- いずれかのプレイヤーが正解のToriFudaを取得
+
+**ゲーム終盤の挙動**
+
+- Stackが空になった後もゲームは継続
+- Tatami上の札は取られるたびに減っていく
+- 最後のYomiFudaに対応するToriFudaが取られた時点でゲーム終了
+
+##### Phase 5: ゲーム終了
+
+**終了条件**
+
+- すべてのYomiFuda/ToriFudaペアがなくなる
+- または制限時間終了 (BOX仕様による)
+
+**結果表示**
+
+- 各プレイヤーの獲得枚数
+- スコア
+- プレイ時間
+
+### プレイヤー人数
+
+- **1人**: シングルプレイ (タイムアタック、完走モード)
+- **2-4人**: マルチプレイヤー (早い者勝ち)
+
+各プレイヤーは獲得したToriFudaを自分のMochiFudaに保持し、最終的に最も多くの札を獲得したプレイヤーが勝利。
+
+### 入力方式
+
+- **Keyboard**: PC環境向け、ショートカットキーで操作
+- **Touch**: モバイル/タブレット環境向け、タップで操作
+
+### 勝利条件
+
+- 最も多くの札を取ったプレイヤーが勝利
+- シングルプレイの場合: スコアとタイムを記録
+
+### 画面遷移フロー
+
+```
+1. タイトル画面
+   - アプリタイトル
+   - 入力方式選択 (Keyboard / Touch)
+   ↓ (入力方式決定)
+
+2. プレイヤー人数選択画面
+   - プレイヤー人数選択 (1-4人)
+   - (Touch時: 画面分割プレビュー表示)
+   ↓ (次へ)
+
+3. BOX選択画面
+   - 利用可能なBOX一覧表示
+   - BOX選択
+   ↓ (ゲーム開始)
+
+4. ゲーム画面
+   - YomiFuda表示エリア (共通)
+   - Tatamiエリア (5枚のToriFuda)
+     * Keyboard: 共通エリア
+     * Touch: 各プレイヤー専用エリア
+   - MochiFudaエリア (各プレイヤー)
+   - スコア/タイマー表示
+   ↓ (全Race終了)
+
+5. 結果画面
+   - 各プレイヤーのスコア
+   - 獲得枚数ランキング
+   - プレイ時間
+   - リプレイ/タイトルへ戻る
+```
+
+## Screen Design
+
+### 1. タイトル画面
+
+- アプリタイトル (PP Karuta)
+- 入力方式選択:
+    - [Keyboard] ボタン (PC環境向け)
+    - [Touch] ボタン (モバイル/タブレット向け)
+- ルール説明へのリンク
+- PROMIDAS統計情報(オプション)
+
+**この画面で入力方式を決定することで、以降の画面レイアウトが確定する**
+
+### 2. プレイヤー人数選択画面
+
+**プレイヤー人数選択**
+
+- [1人] [2人] [3人] [4人] ボタン
+
+**Touch モードの場合**
+
+- 選択した人数に応じた画面分割プレビューを表示
+- 例: 2人選択時 → 上下分割のプレビュー
+
+**次へボタン**
+
+### 3. BOX選択画面
+
+**BOX一覧**
+
+- 利用可能なBOXをカード形式で表示
+- 各BOXに表示する情報:
+    - BOX名
+    - 説明
+    - 札の枚数
+    - 難易度
+    - タイムリミット (あれば)
+
+**BOX選択**
+
+- クリック/タップでBOXを選択
+- ゲーム開始ボタン
+
+### 4. ゲーム画面
+
+**Keyboardモードのレイアウト:**
+
+```
+┌─────────────────────────────────────┐
+│  YomiFuda表示エリア (共通)        │
+│  「このプロトタイプは...」            │
+├─────────────────────────────────────┤
+│  Tatamiエリア (共通, 5枚)          │
+│  [1] [2] [3] [4] [5]                │
+│  札A 札B 札C 札D 札E                │
+├─────────────────────────────────────┤
+│  プレイヤー情報エリア              │
+│  P1: 3枚 | P2: 5枚 | P3: 2枚      │
+│  スコア | タイマー | 進行状況      │
+└─────────────────────────────────────┘
+```
+
+**Touchモードのレイアウト (2人の例):**
+
+```
+┌─────────────────────────────────────┐
+│  YomiFuda表示エリア (共通)        │
+├───────────────────┬──────────────────┤
+│ Player 1 Tatami   │ Player 2 Tatami   │
+│ [1][2][3][4][5]   │ [1][2][3][4][5]   │
+│ MochiFuda: 3枚    │ MochiFuda: 5枚    │
+└───────────────────┴──────────────────┘
+```
+
+**コンポーネント:**
+
+- YomiFuda表示エリア (上部、全プレイヤー共通)
+- Tatamiエリア (5枚のToriFudaを表示)
+    - Keyboard: 1つの共通エリア
+    - Touch: プレイヤー数分のエリア (同じToriFudaを表示)
+- MochiFudaエリア (各プレイヤーの獲得札)
+- 情報表示エリア (スコア/タイマー/進行状況)
+
+### 5. 結果画面
+
+- 各プレイヤーの最終スコア
+- 獲得枚数ランキング
+- プレイ時間
+- リプレイボタン
+- タイトルへ戻るボタン
+
+## Data Model
+
+### BOX Configuration
+
+BOXはゲームの仕様を定義する設定オブジェクト:
+
+```typescript
+type BoxConfig = {
+    id: string;
+    name: string;
+    description: string;
+
+    // データフィルタ条件
+    filter: {
+        tags?: string[]; // 特定のタグを持つプロトタイプ
+        year?: number; // 特定年のプロトタイプ
+        author?: string; // 特定の作者
+        hasImage?: boolean; // 画像有無
+    };
+
+    // ゲーム設定
+    cardCount: number; // 使用する札の枚数
+    difficulty: 'easy' | 'normal' | 'hard'; // 難易度
+    timeLimit?: number; // 制限時間 (ミリ秒、なければ無制限)
+};
+```
+
+### Game Configuration
+
+ゲーム開始時に決定される設定:
+
+```typescript
+type GameConfig = {
+    playerCount: number; // 1-4
+    inputMode: 'keyboard' | 'touch';
+    selectedBox: BoxConfig;
+};
+```
+
+### Player Data
+
+各プレイヤーの状態:
+
+```typescript
+type Player = {
+    id: string;
+    name: string; // "Player 1", "Player 2", etc.
+    mochiFuda: ToriFuda[]; // 獲得した札
+    score: number;
+    correctCount: number; // 正解数
+    wrongCount: number; // 不正解数
+
+    // Keyboardモードの場合
+    keyBindings?: string[]; // [‘1’, ‘2’, ‘3’, ‘4’, ‘5’]
+};
+```
+
+### Fuda (札) Data Models
+
+ProtoPediaのプロトタイプデータから YomiFuda と ToriFuda を生成:
+
+```typescript
+// 元データ(ProtoPediaのプロトタイプ)
+type PrototypeData = {
+    id: string;
+    title: string;
+    description: string;
+    thumbnailUrl?: string;
+    author: string;
+    tags: string[];
+    // その他のフィールド
+};
+
+// 読み札
+type YomiFuda = {
+    id: string;
+    prototypeId: string; // 対応する PrototypeData の id
+    text: string; // description から生成
+};
+
+// 取り札
+type ToriFuda = {
+    id: string;
+    prototypeId: string; // 対応する PrototypeData の id
+    title: string;
+    thumbnailUrl?: string;
+    isAcquired: boolean; // 獲得済みかどうか
+};
+
+// YomiFuda と ToriFuda の対応関係は prototypeId で判定する
+```
+
+### Game State
+
+```typescript
+type GameState = {
+    status: 'idle' | 'setup' | 'boxSelection' | 'playing' | 'finished';
+
+    // ゲーム設定
+    config: GameConfig;
+
+    // プレイヤー情報
+    players: Player[]; // 1-4人
+
+    // 札の状態
+    allYomiFuda: YomiFuda[]; // ゲームで使用するすべての読み札
+    allToriFuda: ToriFuda[]; // ゲームで使用するすべての取り札
+    currentYomiFuda: YomiFuda | null; // 現在表示中の読み札
+    currentTatamiToriFuda: ToriFuda[]; // 現在Tatamiに表示されている5枚
+
+    // 進行状況
+    currentRace: number; // 現在のRace (1から開始)
+    totalRaces: number; // 全体のRace数 (= allYomiFuda.length)
+
+    // 時間管理
+    startTime: number | null;
+    endTime: number | null;
+    elapsedTime: number; // 経過時間 (ミリ秒)
+};
+```
+
+### Game Settings
+
+```typescript
+type GameSettings = {
+    mode: 'single' | 'vsCpu' | 'practice';
+    difficulty: 'easy' | 'normal' | 'hard';
+    numberOfCards: number; // 10, 20, 50, 100
+    timeLimit?: number; // ミリ秒、練習モードではnull
+};
+```
+
+## Component Architecture
+
+### Container/Presentational Pattern
+
+すべてのコンポーネントは以下のパターンに従う:
+
+- **Container**: データ取得、状態管理、ビジネスロジック
+- **Presentational**: UIレンダリング、propsを受け取って表示のみ
+
+### 主要コンポーネント
+
+```
+src/
+  components/
+    app/
+      AppContainer.tsx          # アプリケーション全体のコンテナ
+      AppPresentation.tsx       # アプリケーション全体のレイアウト
+
+    title/
+      TitleContainer.tsx        # タイトル画面のロジック
+      TitlePresentation.tsx     # タイトル画面のUI
+
+    game/
+      GameContainer.tsx         # ゲームロジック、状態管理
+      GamePresentation.tsx      # ゲーム画面全体のUI
+      YomiFuda.tsx              # 読み札コンポーネント(Presentational)
+      ToriFuda.tsx              # 取り札コンポーネント(Presentational)
+      Tatami.tsx                # 畳エリア(複数のToriFudaを配置)
+      MochiFuda.tsx             # 持ち札エリア(獲得した札を表示)
+      ScoreBoard.tsx            # スコアボード
+      Timer.tsx                 # タイマー
+
+    result/
+      ResultContainer.tsx       # 結果画面のロジック
+      ResultPresentation.tsx    # 結果画面のUI
+
+    common/
+      Button.tsx                # 共通ボタン
+      Card.tsx                  # 共通カードUI
+      Modal.tsx                 # モーダル
+```
+
+### State Management
+
+- Reactの`useState`と`useReducer`を使用
+- グローバル状態が必要な場合はContext APIを検討
+- ゲーム状態は`GameContainer`で管理
+
+### Routing (TODO: 決定が必要)
+
+- React Router導入の必要性を検討
+- または、状態ベースのシンプルな画面切り替え
+
+## Technical Specifications
+
+### Tech Stack
+
+- **TypeScript 5.9**: 型安全性
+- **React 19**: UIライブラリ
+- **Vite 7**: ビルドツール
+- **Tailwind CSS 4.x**: スタイリング
+- **PROMIDAS**: データ管理
+- **Vitest 4**: テストフレームワーク
+- **Testing Library**: コンポーネントテスト
+
+### Browser Support
+
+- モダンブラウザ(Chrome, Firefox, Safari, Edge)の最新バージョン
+- ES2022+対応ブラウザ
+
+### Performance Goals
+
+- 初回ロード: 3秒以内
+- ゲーム操作のレスポンス: 100ms以内
+- PROMIDASキャッシュ活用により、ゲーム中のAPI呼び出しを最小化
+
+## Testing Strategy
+
+### Unit Tests
+
+- すべてのPresentationalコンポーネントに対してレンダリングテスト
+- ゲームロジックの単体テスト
+- データ変換ロジックのテスト
+
+### Component Tests
+
+- Testing Libraryを使用したインタラクションテスト
+- ユーザーイベントのシミュレーション
+
+### E2E Tests (TODO)
+
+- 必要に応じてPlaywrightなどを導入
+
+## Development Roadmap
+
+### Phase 1: 基本実装 (Current)
+
+- [x] プロジェクトセットアップ
+- [x] PROMIDAS統合
+- [x] Container/Presentational基本構造
+- [ ] タイトル画面
+- [ ] 基本的なゲームロジック
+- [ ] シンプルなゲーム画面
+
+### Phase 2: コア機能
+
+- [ ] ゲーム設定画面
+- [ ] スコアリングシステム
+- [ ] タイマー機能
+- [ ] 結果画面
+
+### Phase 3: 拡張機能
+
+- [ ] 難易度調整
+- [ ] ゲームモード追加
+- [ ] アニメーション
+- [ ] サウンドエフェクト(オプション)
+
+### Phase 4: 最適化
+
+- [ ] パフォーマンス改善
+- [ ] アクセシビリティ対応
+- [ ] レスポンシブデザイン
+
+## Open Questions & Decisions Needed
+
+1. **ゲームルールの最終決定**
+    - どのマッチング方式を採用するか?
+    - 複数モードを実装するか?
+
+2. **UI/UXデザイン**
+    - 和風デザインにするか?
+    - アニメーションの範囲は?
+
+3. **データの使い方**
+    - プロトタイプのどのフィールドを主に使用するか?
+    - 画像がないプロトタイプの扱いは?
+
+4. **スコアリング**
+    - 正解数のみ? タイムボーナスは?
+    - ランキング機能の必要性は?
+
+5. **ルーティング**
+    - React Router導入? それとも状態管理のみ?
+
+## References
+
+- [Karuta - Wikipedia](https://en.wikipedia.org/wiki/Karuta)
+- [PROMIDAS](https://github.com/F88/promidas)
+- [PROMIDAS Utilities](https://github.com/F88/promidas-utils)
+- [ProtoPedia](https://protopedia.net/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@faker-js/faker": "^10.1.0",
         "@storybook/builder-vite": "^10.1.10",
         "@storybook/react-vite": "^10.1.10",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1162,6 +1163,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.1.0.tgz",
+      "integrity": "sha512-C3mrr3b5dRVlKPJdfrAXS8+dq+rq8Qm5SNRazca0JKgw1HQERFmrVb0towvMmw5uu8hHKNiQasMaR/tydf3Zsg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@faker-js/faker": "^10.1.0",
     "@storybook/builder-vite": "^10.1.10",
     "@storybook/react-vite": "^10.1.10",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,34 @@
 import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PrototypeInMemoryStats } from '@f88/promidas';
+import { AppPresentation } from '@/components/app/AppPresentation';
 
 describe('App', () => {
-  it('should pass dummy test', () => {
-    expect(true).toBe(true);
+  it('renders loading state', () => {
+    render(<AppPresentation loading error={null} stats={null} />);
+    expect(screen.getByText('Loading PROMIDAS...')).toBeInTheDocument();
   });
 
-  it('should perform basic math', () => {
-    expect(1 + 1).toBe(2);
+  it('renders error state', () => {
+    render(<AppPresentation loading={false} error="Boom" stats={null} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Error:');
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+  });
+
+  it('renders stats', () => {
+    const stats: PrototypeInMemoryStats = {
+      size: 123,
+      cachedAt: new Date(1730000000000),
+      isExpired: false,
+      remainingTtlMs: 300000,
+      dataSizeBytes: 1024,
+      refreshInFlight: false,
+    };
+
+    render(<AppPresentation loading={false} error={null} stats={stats} />);
+
+    expect(screen.getByText('PROMIDAS Stats')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,82 +1,96 @@
-import { useEffect, useState } from 'react';
-import { getPromidasRepository } from './lib/promidas';
-import type { PrototypeInMemoryStats } from '@f88/promidas';
+import { useState, useCallback } from 'react';
 import './App.css';
+import { RecipeSelectorContainer } from '@/components/recipeSelector/RecipeSelectorContainer';
+import { TatamiViewContainer } from '@/components/tatamiView/TatamiViewContainer';
+import { GameResultsContainer } from '@/components/gameResults/GameResultsContainer';
+import { createInitialState } from '@/lib/karuta';
+import type { GameState } from '@/models/karuta';
 
 function App() {
-  const [stats, setStats] = useState<PrototypeInMemoryStats | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [gameState, setGameState] = useState<Omit<GameState, 'players'> | null>(
+    null,
+  );
+  const [score, setScore] = useState(0);
+  const [mochiFuda, setMochiFuda] = useState<number[]>([]);
 
-  useEffect(() => {
-    const initPromidas = async () => {
-      try {
-        const repo = await getPromidasRepository();
-        const repoStats = repo.getStats();
-        setStats(repoStats);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
-      } finally {
-        setLoading(false);
+  const handleCorrectAnswer = useCallback((cardId: number) => {
+    // Add to mochiFuda
+    setMochiFuda((prev) => [...prev, cardId]);
+
+    // Add 1 point
+    setScore((prev) => prev + 1);
+
+    // Update Tatami: remove the card and add from stack if available
+    setGameState((prev) => {
+      if (!prev) return prev;
+
+      const newTatami = prev.tatami.filter((id) => id !== cardId);
+      const newStack = [...prev.stack];
+
+      // If stack has cards, add one to tatami
+      if (newStack.length > 0) {
+        const nextCard = newStack.shift()!;
+        newTatami.push(nextCard);
       }
-    };
 
-    initPromidas();
+      return {
+        ...prev,
+        tatami: newTatami,
+        stack: newStack,
+      };
+    });
   }, []);
 
-  return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <div className="mx-auto max-w-4xl">
-        <h1 className="mb-8 text-4xl font-bold text-gray-900">HELLO WORLD</h1>
+  const handleIncorrectAnswer = useCallback(() => {
+    // Subtract 1 point
+    setScore((prev) => prev - 1);
+  }, []);
 
-        {loading && <div className="text-gray-600">Loading PROMIDAS...</div>}
+  const handleBackToTop = useCallback(() => {
+    setGameState(null);
+    setScore(0);
+    setMochiFuda([]);
+  }, []);
 
-        {error && (
-          <div
-            className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700"
-            role="alert"
-          >
-            <strong className="font-bold">Error:</strong>
-            <span className="block sm:inline"> {error}</span>
-          </div>
-        )}
+  const handleReplay = useCallback(() => {
+    if (!gameState) return;
 
-        {stats && (
-          <div className="rounded-lg bg-white p-6 shadow">
-            <h2 className="mb-4 text-2xl font-semibold text-gray-800">
-              PROMIDAS Stats
-            </h2>
-            <dl className="space-y-2">
-              <div>
-                <dt className="text-sm font-medium text-gray-500">
-                  Loaded prototypes:
-                </dt>
-                <dd className="text-lg text-gray-900">{stats.size}</dd>
-              </div>
-              <div>
-                <dt className="text-sm font-medium text-gray-500">
-                  Cached at:
-                </dt>
-                <dd className="text-lg text-gray-900">
-                  {stats.cachedAt
-                    ? new Date(stats.cachedAt).toLocaleString('ja-JP')
-                    : 'N/A'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-sm font-medium text-gray-500">
-                  Is expired:
-                </dt>
-                <dd className="text-lg text-gray-900">
-                  {stats.isExpired ? 'Yes' : 'No'}
-                </dd>
-              </div>
-            </dl>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+    // Regenerate stack and tatami from existing deck
+    const newState = createInitialState(gameState.deck);
+    setGameState(newState);
+    setScore(0);
+    setMochiFuda([]);
+  }, [gameState]);
+
+  // Game is over when all cards are acquired
+  // completedRaces = mochiFuda.length (single player)
+  const isGameOver = gameState && mochiFuda.length >= gameState.deck.size;
+
+  if (isGameOver && gameState) {
+    return (
+      <GameResultsContainer
+        deck={gameState.deck}
+        score={score}
+        mochiFuda={mochiFuda}
+        onBackToTop={handleBackToTop}
+        onReplay={handleReplay}
+      />
+    );
+  }
+
+  if (gameState) {
+    return (
+      <TatamiViewContainer
+        gameState={gameState}
+        score={score}
+        mochiFuda={mochiFuda}
+        onCorrectAnswer={handleCorrectAnswer}
+        onIncorrectAnswer={handleIncorrectAnswer}
+      />
+    );
+  }
+
+  return <RecipeSelectorContainer onGameStateCreated={setGameState} />;
 }
 
 export default App;

--- a/src/components/app/AppContainer.tsx
+++ b/src/components/app/AppContainer.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import type { PrototypeInMemoryStats } from '@f88/promidas';
+import { getPromidasRepository } from '@/lib/promidas';
+import { AppPresentation } from './AppPresentation';
+
+export function AppContainer() {
+  const [stats, setStats] = useState<PrototypeInMemoryStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const initPromidas = async () => {
+      try {
+        const repo = await getPromidasRepository();
+        const repoStats = repo.getStats();
+        setStats(repoStats);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void initPromidas();
+  }, []);
+
+  return <AppPresentation loading={loading} error={error} stats={stats} />;
+}

--- a/src/components/app/AppPresentation.tsx
+++ b/src/components/app/AppPresentation.tsx
@@ -1,0 +1,67 @@
+import type { PrototypeInMemoryStats } from '@f88/promidas';
+
+export type AppPresentationProps = {
+  loading: boolean;
+  error: string | null;
+  stats: PrototypeInMemoryStats | null;
+};
+
+export function AppPresentation({
+  loading,
+  error,
+  stats,
+}: AppPresentationProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-8 text-4xl font-bold text-gray-900">PP Karuta</h1>
+
+        {loading && <div className="text-gray-600">Loading PROMIDAS...</div>}
+
+        {error && (
+          <div
+            className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700"
+            role="alert"
+          >
+            <strong className="font-bold">Error:</strong>
+            <span className="block sm:inline"> {error}</span>
+          </div>
+        )}
+
+        {stats && (
+          <div className="rounded-lg bg-white p-6 shadow">
+            <h2 className="mb-4 text-2xl font-semibold text-gray-800">
+              PROMIDAS Stats
+            </h2>
+            <dl className="space-y-2">
+              <div>
+                <dt className="text-sm font-medium text-gray-500">
+                  Loaded prototypes:
+                </dt>
+                <dd className="text-lg text-gray-900">{stats.size}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">
+                  Cached at:
+                </dt>
+                <dd className="text-lg text-gray-900">
+                  {stats.cachedAt
+                    ? new Date(stats.cachedAt).toLocaleString('ja-JP')
+                    : 'N/A'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">
+                  Is expired:
+                </dt>
+                <dd className="text-lg text-gray-900">
+                  {stats.isExpired ? 'Yes' : 'No'}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gameResults/GameResultsContainer.tsx
+++ b/src/components/gameResults/GameResultsContainer.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+import { getPrototypesByIds } from '@/lib/karuta';
+import { GameResultsPresentation } from './GameResultsPresentation';
+
+export type GameResultsContainerProps = {
+  deck: Map<number, NormalizedPrototype>;
+  score: number;
+  mochiFuda: number[];
+  onBackToTop: () => void;
+  onReplay: () => void;
+};
+
+export function GameResultsContainer({
+  deck,
+  score,
+  mochiFuda,
+  onBackToTop,
+  onReplay,
+}: GameResultsContainerProps) {
+  const mochiFudaCards = getPrototypesByIds(deck, mochiFuda);
+
+  const handleBackToTop = useCallback(() => {
+    console.log('🏠 Back to TOP');
+    onBackToTop();
+  }, [onBackToTop]);
+
+  const handleReplay = useCallback(() => {
+    console.log('🔄 Replay - Regenerating stack from deck');
+    onReplay();
+  }, [onReplay]);
+
+  return (
+    <GameResultsPresentation
+      score={score}
+      mochiFudaCards={mochiFudaCards}
+      onBackToTop={handleBackToTop}
+      onReplay={handleReplay}
+    />
+  );
+}

--- a/src/components/gameResults/GameResultsPresentation.tsx
+++ b/src/components/gameResults/GameResultsPresentation.tsx
@@ -1,0 +1,82 @@
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+export type GameResultsPresentationProps = {
+  score: number;
+  mochiFudaCards: NormalizedPrototype[];
+  onBackToTop: () => void;
+  onReplay: () => void;
+};
+
+export function GameResultsPresentation({
+  score,
+  mochiFudaCards,
+  onBackToTop,
+  onReplay,
+}: GameResultsPresentationProps) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 p-8">
+      <div className="mx-auto max-w-4xl">
+        {/* Header */}
+        <div className="mb-8 text-center">
+          <h1 className="mb-2 text-4xl font-bold text-gray-800">
+            🎉 Game Complete!
+          </h1>
+          <p className="text-xl text-gray-600">お疲れ様でした！</p>
+        </div>
+
+        {/* Score */}
+        <div className="mb-6 rounded-lg bg-white p-6 shadow-lg">
+          <div className="text-center">
+            <p className="mb-2 text-lg text-gray-600">Final Score</p>
+            <p className="text-5xl font-bold text-indigo-600">{score}</p>
+          </div>
+        </div>
+
+        {/* MochiFuda */}
+        <div className="mb-8 rounded-lg bg-white p-6 shadow-lg">
+          <h2 className="mb-4 text-2xl font-bold text-gray-800">
+            MochiFuda ({mochiFudaCards.length} cards)
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {mochiFudaCards.map((card) => (
+              <div
+                key={card.id}
+                className="rounded-lg border p-4 transition-shadow hover:shadow-md"
+              >
+                {card.mainUrl && (
+                  <img
+                    src={card.mainUrl}
+                    alt={card.prototypeNm}
+                    className="mb-2 h-32 w-full rounded object-cover"
+                  />
+                )}
+                <h3 className="mb-1 text-sm font-semibold text-gray-800">
+                  {card.prototypeNm}
+                </h3>
+                <p className="line-clamp-2 text-xs text-gray-600">
+                  {card.summary}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex flex-col justify-center gap-4 sm:flex-row">
+          <button
+            onClick={onBackToTop}
+            className="rounded-lg bg-gray-600 px-8 py-4 font-semibold text-white shadow-lg transition-colors hover:bg-gray-700"
+          >
+            🏠 TOP
+          </button>
+          <button
+            onClick={onReplay}
+            className="rounded-lg bg-indigo-600 px-8 py-4 font-semibold text-white shadow-lg transition-colors hover:bg-indigo-700"
+          >
+            🔄 Replay
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipeSelector/RecipeSelectorContainer.tsx
+++ b/src/components/recipeSelector/RecipeSelectorContainer.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import type { DeckRecipe, GameState } from '@/models/karuta';
+import {
+  DECK_RECIPES,
+  generateDummyPrototypes,
+  generateDeck,
+  createInitialState,
+} from '@/lib/karuta';
+import { RecipeSelectorPresentation } from './RecipeSelectorPresentation';
+
+export type RecipeSelectorContainerProps = {
+  onGameStateCreated: (gameState: Omit<GameState, 'players'>) => void;
+};
+
+export function RecipeSelectorContainer({
+  onGameStateCreated,
+}: RecipeSelectorContainerProps) {
+  const handleSelectRecipe = useCallback(
+    (recipe: DeckRecipe) => {
+      console.group(`🎴 Selected Recipe: ${recipe.title}`);
+
+      // Generate dummy prototypes
+      const allPrototypes = generateDummyPrototypes(30);
+      console.log(`Generated ${allPrototypes.length} dummy prototypes`);
+
+      // Generate deck from recipe
+      const deck = generateDeck(recipe, allPrototypes);
+      console.log(`Generated deck with ${deck.size} cards`);
+
+      // Create initial game state
+      const initialState = createInitialState(deck);
+      console.log('Initial GameState:', initialState);
+
+      console.groupEnd();
+
+      // Notify parent
+      onGameStateCreated(initialState);
+    },
+    [onGameStateCreated],
+  );
+
+  return (
+    <RecipeSelectorPresentation
+      recipes={DECK_RECIPES}
+      onSelectRecipe={handleSelectRecipe}
+    />
+  );
+}

--- a/src/components/recipeSelector/RecipeSelectorPresentation.tsx
+++ b/src/components/recipeSelector/RecipeSelectorPresentation.tsx
@@ -1,0 +1,43 @@
+import type { DeckRecipe } from '@/models/karuta';
+
+export type RecipeSelectorPresentationProps = {
+  recipes: DeckRecipe[];
+  onSelectRecipe: (recipe: DeckRecipe) => void;
+};
+
+export function RecipeSelectorPresentation({
+  recipes,
+  onSelectRecipe,
+}: RecipeSelectorPresentationProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-8">
+      <div className="w-full max-w-6xl">
+        <h1 className="mb-12 text-center text-4xl font-bold text-gray-800">
+          🎴 Select Deck Recipe
+        </h1>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {recipes.map((recipe) => (
+            <button
+              key={recipe.id}
+              onClick={() => onSelectRecipe(recipe)}
+              className="group relative overflow-hidden rounded-2xl bg-white p-8 shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl active:scale-95"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-blue-400 to-indigo-500 opacity-0 transition-opacity group-hover:opacity-10" />
+              <div className="relative">
+                <h2 className="mb-4 text-2xl font-bold text-gray-800">
+                  {recipe.title}
+                </h2>
+                <div className="flex items-center gap-2 text-lg text-gray-600">
+                  <span className="text-3xl font-bold text-indigo-600">
+                    {recipe.deckSize}
+                  </span>
+                  <span>{recipe.deckSize === 1 ? 'Race' : 'Races'}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tatamiView/TatamiViewContainer.tsx
+++ b/src/components/tatamiView/TatamiViewContainer.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import type { GameState } from '@/models/karuta';
+import { getPrototypesByIds } from '@/lib/karuta';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+import { TatamiViewPresentation } from './TatamiViewPresentation';
+
+export type TatamiViewContainerProps = {
+  gameState: Omit<GameState, 'players'>;
+  score: number;
+  mochiFuda: number[]; // Array of cardId (prototypeId)
+  onCorrectAnswer: (cardId: number) => void;
+  onIncorrectAnswer: () => void;
+};
+
+export function TatamiViewContainer({
+  gameState,
+  score,
+  mochiFuda,
+  onCorrectAnswer,
+  onIncorrectAnswer,
+}: TatamiViewContainerProps) {
+  // Calculate current race from completed races (mochiFuda count)
+  const completedRaces = mochiFuda.length;
+  const currentRace = completedRaces + 1;
+
+  // Get current YomiFuda (0-indexed by completedRaces)
+  const deckArray = [...gameState.deck.values()];
+  const currentYomiFuda = deckArray[completedRaces];
+
+  // Get Tatami cards
+  const tatamiCards = getPrototypesByIds(gameState.deck, gameState.tatami);
+
+  const handleSelectCard = useCallback(
+    (selectedCard: NormalizedPrototype) => {
+      const isCorrect = selectedCard.id === currentYomiFuda.id;
+
+      console.group(isCorrect ? '✅ Correct!' : '❌ Incorrect!');
+      console.log(
+        'Selected:',
+        selectedCard.prototypeNm,
+        `(ID: ${selectedCard.id})`,
+      );
+      console.log(
+        'Answer:',
+        currentYomiFuda.prototypeNm,
+        `(ID: ${currentYomiFuda.id})`,
+      );
+      console.groupEnd();
+
+      if (isCorrect) {
+        onCorrectAnswer(selectedCard.id);
+      } else {
+        onIncorrectAnswer();
+      }
+    },
+    [currentYomiFuda, onCorrectAnswer, onIncorrectAnswer],
+  );
+
+  return (
+    <TatamiViewPresentation
+      yomiFuda={currentYomiFuda}
+      tatamiCards={tatamiCards}
+      currentRace={currentRace}
+      totalRaces={gameState.deck.size}
+      stackCount={gameState.stack.length}
+      score={score}
+      mochiFudaCount={mochiFuda.length}
+      onSelectCard={handleSelectCard}
+    />
+  );
+}

--- a/src/components/tatamiView/TatamiViewPresentation.tsx
+++ b/src/components/tatamiView/TatamiViewPresentation.tsx
@@ -1,0 +1,134 @@
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+export type TatamiViewPresentationProps = {
+  yomiFuda: NormalizedPrototype;
+  tatamiCards: NormalizedPrototype[];
+  currentRace: number;
+  totalRaces: number;
+  stackCount: number;
+  score: number;
+  mochiFudaCount: number;
+  onSelectCard: (card: NormalizedPrototype) => void;
+};
+
+export function TatamiViewPresentation({
+  yomiFuda,
+  tatamiCards,
+  currentRace,
+  totalRaces,
+  stackCount,
+  score,
+  mochiFudaCount,
+  onSelectCard,
+}: TatamiViewPresentationProps) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-teal-100 p-4">
+      <div className="mx-auto max-w-7xl">
+        {/* Header */}
+        <div className="mb-4 text-center">
+          <h1 className="mb-2 text-3xl font-bold text-gray-800">🎴 Karuta</h1>
+          <div className="flex items-center justify-center gap-4 text-lg text-gray-600">
+            <span>
+              Race {currentRace} / {totalRaces}
+            </span>
+            <span className="text-gray-400">•</span>
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-yellow-600">Score:</span>
+              <span className="rounded-full bg-yellow-100 px-3 py-1 text-sm font-bold text-yellow-700">
+                {score} pts
+              </span>
+            </span>
+            <span className="text-gray-400">•</span>
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-pink-600">MochiFuda:</span>
+              <span className="rounded-full bg-pink-100 px-3 py-1 text-sm font-bold text-pink-700">
+                {mochiFudaCount} cards
+              </span>
+            </span>
+            <span className="text-gray-400">•</span>
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-indigo-600">Stack:</span>
+              <span className="rounded-full bg-indigo-100 px-3 py-1 text-sm font-bold text-indigo-700">
+                {stackCount} remaining
+              </span>
+            </span>
+            <span className="text-gray-400">•</span>
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-green-600">Tatami:</span>
+              <span className="rounded-full bg-green-100 px-3 py-1 text-sm font-bold text-green-700">
+                {tatamiCards.length} cards
+              </span>
+            </span>
+          </div>
+        </div>
+
+        {/* YomiFuda Area */}
+        <div className="mb-8 rounded-2xl bg-white p-8 shadow-xl">
+          <div className="mb-4 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-indigo-600">📖 YomiFuda</h2>
+            <span className="rounded-full bg-indigo-100 px-3 py-1 text-sm font-semibold text-indigo-700">
+              {yomiFuda.prototypeNm}
+            </span>
+          </div>
+          <p className="text-lg leading-relaxed text-gray-700">
+            {yomiFuda.summary || yomiFuda.freeComment || 'No description'}
+          </p>
+        </div>
+
+        {/* Tatami Label */}
+        <h2 className="mb-4 text-center text-2xl font-bold text-gray-800">
+          🃏 ToriFuda - Select the correct card!
+        </h2>
+
+        {/* Tatami Cards Grid */}
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          {tatamiCards.map((card, index) => (
+            <button
+              key={card.id}
+              onClick={() => onSelectCard(card)}
+              className="group relative overflow-hidden rounded-xl bg-white p-6 shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl active:scale-95"
+            >
+              {/* Card Number Badge */}
+              <div className="absolute top-2 right-2 flex h-8 w-8 items-center justify-center rounded-full bg-indigo-500 text-sm font-bold text-white">
+                {index + 1}
+              </div>
+
+              {/* Card Image */}
+              <div className="mb-4 aspect-video overflow-hidden rounded-lg bg-gray-200">
+                <img
+                  src={card.mainUrl}
+                  alt={card.prototypeNm}
+                  className="h-full w-full object-cover"
+                  onError={(e) => {
+                    e.currentTarget.src =
+                      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100"%3E%3Crect fill="%23ddd" width="100" height="100"/%3E%3Ctext x="50%25" y="50%25" text-anchor="middle" dy=".3em" fill="%23999"%3ENo Image%3C/text%3E%3C/svg%3E';
+                  }}
+                />
+              </div>
+
+              {/* Card Title */}
+              <h3 className="mb-2 line-clamp-2 text-lg font-semibold text-gray-800">
+                {card.prototypeNm}
+              </h3>
+
+              {/* Card Summary */}
+              <p className="line-clamp-3 text-sm text-gray-600">
+                {card.summary || 'No summary available'}
+              </p>
+
+              {/* ID Badge */}
+              <div className="mt-3 text-xs text-gray-400">ID: {card.id}</div>
+            </button>
+          ))}
+        </div>
+
+        {/* Empty State */}
+        {tatamiCards.length === 0 && (
+          <div className="py-20 text-center text-gray-500">
+            <p className="text-xl">No cards on Tatami</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/karuta/deck/accessor.ts
+++ b/src/lib/karuta/deck/accessor.ts
@@ -1,0 +1,30 @@
+import type { Deck } from '@/models/karuta';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+/**
+ * Get NormalizedPrototype from deck by ID
+ * @param deck - Deck map
+ * @param id - Prototype ID
+ * @returns NormalizedPrototype or undefined
+ */
+export function getPrototypeById(
+  deck: Deck,
+  id: number,
+): NormalizedPrototype | undefined {
+  return deck.get(id);
+}
+
+/**
+ * Get multiple NormalizedPrototypes from deck by IDs
+ * @param deck - Deck map
+ * @param ids - Prototype IDs
+ * @returns Array of NormalizedPrototypes (filters out not found)
+ */
+export function getPrototypesByIds(
+  deck: Deck,
+  ids: number[],
+): NormalizedPrototype[] {
+  return ids
+    .map((id) => deck.get(id))
+    .filter((p): p is NormalizedPrototype => p !== undefined);
+}

--- a/src/lib/karuta/deck/hash.ts
+++ b/src/lib/karuta/deck/hash.ts
@@ -1,0 +1,68 @@
+import type {
+  Deck,
+  DeckIdentifier,
+  DeckMetaData,
+  DeckIdsHash,
+} from '@/models/karuta';
+import { getDeckIds } from './utils';
+
+/**
+ * Generate SHA-256 hash from string
+ */
+async function sha256(message: string): Promise<string> {
+  const msgBuffer = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return hashHex;
+}
+
+/**
+ * Create DeckIdsHash from prototype IDs
+ * Same IDs = Same hash (reproducible)
+ */
+export async function createDeckIdsHash(
+  prototypeIds: number[],
+): Promise<DeckIdsHash> {
+  const sortedIds = [...prototypeIds].sort((a, b) => a - b);
+  const source = sortedIds.join(',');
+  return await sha256(source);
+}
+
+/**
+ * Create DeckIdentifier from deck and fetch timestamp
+ */
+export async function createDeckIdentifier(
+  deck: Deck,
+  fetchedAt: number,
+): Promise<DeckIdentifier> {
+  const prototypeIds = getDeckIds(deck);
+  const source = `${fetchedAt}:${prototypeIds.join(',')}`;
+  const deckHash = await sha256(source);
+  return { deckHash };
+}
+
+/**
+ * Create DeckMetaData from deck, fetch timestamp, and title
+ */
+export async function createDeckMetaData(
+  deck: Deck,
+  fetchedAt: number,
+  title: string,
+): Promise<DeckMetaData> {
+  const prototypeIds = getDeckIds(deck);
+
+  // Generate both hashes
+  const deckHash = await sha256(`${fetchedAt}:${prototypeIds.join(',')}`);
+  const deckIdsHash = await sha256(prototypeIds.join(','));
+
+  return {
+    deckHash,
+    deckIdsHash,
+    title,
+    fetchedAt,
+    prototypeIds,
+  };
+}

--- a/src/lib/karuta/deck/index.ts
+++ b/src/lib/karuta/deck/index.ts
@@ -1,0 +1,14 @@
+export {
+  createDeckIdsHash,
+  createDeckIdentifier,
+  createDeckMetaData,
+} from './hash';
+export { getPrototypeById, getPrototypesByIds } from './accessor';
+export {
+  createDeck,
+  getDeckIds,
+  getDeckPrototypes,
+  getDeckSize,
+  hasDeckPrototype,
+  recreateDeck,
+} from './utils';

--- a/src/lib/karuta/deck/utils.ts
+++ b/src/lib/karuta/deck/utils.ts
@@ -1,0 +1,63 @@
+import type { Deck } from '@/models/karuta';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+/**
+ * Create a Deck from array of NormalizedPrototype
+ * Ensures unique IDs by using Map structure
+ */
+export function createDeck(prototypes: NormalizedPrototype[]): Deck {
+  const deckMap = new Map<number, NormalizedPrototype>();
+  for (const prototype of prototypes) {
+    deckMap.set(prototype.id, prototype);
+  }
+  return deckMap;
+}
+
+/**
+ * Get all prototype IDs from deck (sorted)
+ */
+export function getDeckIds(deck: Deck): number[] {
+  return [...deck.keys()].sort((a, b) => a - b);
+}
+
+/**
+ * Get all prototypes from deck as array
+ */
+export function getDeckPrototypes(deck: Deck): NormalizedPrototype[] {
+  return [...deck.values()];
+}
+
+/**
+ * Get deck size
+ */
+export function getDeckSize(deck: Deck): number {
+  return deck.size;
+}
+
+/**
+ * Check if deck contains a prototype by ID
+ */
+export function hasDeckPrototype(deck: Deck, id: number): boolean {
+  return deck.has(id);
+}
+
+/**
+ * Recreate Deck from prototype IDs and full prototype list
+ * Used for regenerating decks from DeckMetaData
+ */
+export function recreateDeck(
+  prototypeIds: number[],
+  allPrototypes: NormalizedPrototype[],
+): Deck {
+  const prototypeMap = new Map(allPrototypes.map((p) => [p.id, p] as const));
+
+  const deckMap = new Map<number, NormalizedPrototype>();
+  for (const id of prototypeIds) {
+    const prototype = prototypeMap.get(id);
+    if (prototype) {
+      deckMap.set(id, prototype);
+    }
+  }
+
+  return deckMap;
+}

--- a/src/lib/karuta/dummy-data.ts
+++ b/src/lib/karuta/dummy-data.ts
@@ -1,0 +1,63 @@
+import { faker } from '@faker-js/faker';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+/**
+ * Generate dummy NormalizedPrototype data for development
+ */
+export function generateDummyPrototypes(
+  count: number = 5,
+): NormalizedPrototype[] {
+  const prototypes: NormalizedPrototype[] = [];
+  const usedIds = new Set<number>();
+
+  for (let i = 0; i < count; i++) {
+    let id: number;
+    do {
+      id = faker.number.int({ min: 1, max: 100000 });
+    } while (usedIds.has(id));
+    usedIds.add(id);
+
+    prototypes.push({
+      id,
+      prototypeNm: faker.commerce.productName(),
+      summary: faker.commerce.productDescription(),
+      freeComment: faker.lorem.paragraph(),
+      systemDescription: faker.lorem.sentence(),
+      mainUrl: faker.image.url(),
+      users: [faker.person.fullName()],
+      tags: faker.helpers.arrayElements(
+        ['IoT', 'AI', 'Robot', 'Education', 'Healthcare', 'Entertainment'],
+        { min: 1, max: 3 },
+      ),
+      materials: [],
+      events: [],
+      awards: [],
+      teamNm: faker.company.name(),
+      createDate: faker.date.past().toISOString(),
+      updateDate: undefined,
+      releaseDate: undefined,
+      officialLink: undefined,
+      videoUrl: undefined,
+      relatedLink: undefined,
+      relatedLink2: undefined,
+      relatedLink3: undefined,
+      relatedLink4: undefined,
+      relatedLink5: undefined,
+      viewCount: faker.number.int({ min: 0, max: 10000 }),
+      goodCount: faker.number.int({ min: 0, max: 1000 }),
+      commentCount: faker.number.int({ min: 0, max: 100 }),
+      releaseFlg: 1,
+      status: 1,
+      createId: undefined,
+      updateId: undefined,
+      uuid: undefined,
+      nid: undefined,
+      revision: undefined,
+      licenseType: undefined,
+      thanksFlg: undefined,
+      slideMode: undefined,
+    });
+  }
+
+  return prototypes;
+}

--- a/src/lib/karuta/index.ts
+++ b/src/lib/karuta/index.ts
@@ -1,0 +1,26 @@
+// Export types
+export type { DeckRecipe, Player, GameState } from '@/models/karuta';
+
+// Export dummy data generation
+export { generateDummyPrototypes } from './dummy-data';
+
+// Export recipe utilities
+export { DECK_RECIPES, findRecipeById, generateDeck } from './recipe';
+
+// Export deck utilities
+export {
+  createDeckIdsHash,
+  createDeckIdentifier,
+  createDeckMetaData,
+  getPrototypeById,
+  getPrototypesByIds,
+  createDeck,
+  getDeckIds,
+  getDeckPrototypes,
+  getDeckSize,
+  hasDeckPrototype,
+  recreateDeck,
+} from './deck';
+
+// Export stack utilities
+export { shuffle, createInitialState } from './stack';

--- a/src/lib/karuta/recipe/definitions.ts
+++ b/src/lib/karuta/recipe/definitions.ts
@@ -1,0 +1,26 @@
+import type { DeckRecipe } from '@/models/karuta';
+
+/**
+ * Available DeckRecipes for selection
+ */
+export const DECK_RECIPES: DeckRecipe[] = [
+  {
+    id: '1-race',
+    title: '1 Race',
+    deckSize: 1,
+  },
+  {
+    id: '3-races',
+    title: '3 Races',
+    deckSize: 3,
+  },
+];
+
+/**
+ * Find a DeckRecipe by id
+ * @param id - Recipe id
+ * @returns DeckRecipe or undefined
+ */
+export function findRecipeById(id: string): DeckRecipe | undefined {
+  return DECK_RECIPES.find((recipe) => recipe.id === id);
+}

--- a/src/lib/karuta/recipe/generator.ts
+++ b/src/lib/karuta/recipe/generator.ts
@@ -1,0 +1,27 @@
+import type { Deck, DeckRecipe } from '@/models/karuta';
+import type { NormalizedPrototype } from '@f88/promidas/types';
+import { createDeck } from '../deck/utils';
+
+/**
+ * Generate a Deck from DeckRecipe
+ * @param recipe - DeckRecipe to generate Deck from
+ * @param allPrototypes - All available prototypes
+ * @returns Generated Deck (Map of ID -> NormalizedPrototype)
+ */
+export function generateDeck(
+  recipe: DeckRecipe,
+  allPrototypes: NormalizedPrototype[],
+): Deck {
+  if (allPrototypes.length < recipe.deckSize) {
+    throw new Error(
+      `Not enough prototypes. Required: ${recipe.deckSize}, Available: ${allPrototypes.length}`,
+    );
+  }
+
+  // Simple random selection without replacement
+  const shuffled = [...allPrototypes].sort(() => Math.random() - 0.5);
+  const selected = shuffled.slice(0, recipe.deckSize);
+
+  // Use createDeck utility for consistency
+  return createDeck(selected);
+}

--- a/src/lib/karuta/recipe/index.ts
+++ b/src/lib/karuta/recipe/index.ts
@@ -1,0 +1,2 @@
+export { DECK_RECIPES, findRecipeById } from './definitions';
+export { generateDeck } from './generator';

--- a/src/lib/karuta/stack.ts
+++ b/src/lib/karuta/stack.ts
@@ -1,0 +1,42 @@
+import type { GameState, Deck } from '@/models/karuta';
+import { getDeckIds } from './deck/utils';
+
+/**
+ * Fisher-Yates shuffle algorithm
+ * @param array - Array to shuffle
+ * @returns Shuffled array (new array, does not mutate original)
+ */
+export function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * Create initial GameState from Deck
+ * @param deck - Deck (Map of ID -> NormalizedPrototype)
+ * @returns Initial GameState with shuffled stack and initial tatami
+ */
+export function createInitialState(deck: Deck): Omit<GameState, 'players'> {
+  if (deck.size === 0) {
+    throw new Error('Deck must not be empty');
+  }
+
+  // Get all IDs and shuffle
+  const allIds = getDeckIds(deck);
+  const shuffledIds = shuffle(allIds);
+
+  // Extract first 5 (or less if deck is smaller) for tatami
+  const initialTatamiSize = Math.min(5, shuffledIds.length);
+  const tatamiIds = shuffledIds.slice(0, initialTatamiSize);
+  const remainingStackIds = shuffledIds.slice(initialTatamiSize);
+
+  return {
+    deck,
+    stack: remainingStackIds,
+    tatami: tatamiIds,
+  };
+}

--- a/src/lib/karuta/stack/index.ts
+++ b/src/lib/karuta/stack/index.ts
@@ -1,0 +1,2 @@
+export { shuffle } from './shuffle';
+export { createInitialState } from './initializer';

--- a/src/lib/karuta/stack/initializer.ts
+++ b/src/lib/karuta/stack/initializer.ts
@@ -1,0 +1,29 @@
+import type { GameState, Deck } from '@/models/karuta';
+import { getDeckIds } from '../deck/utils';
+import { shuffle } from './shuffle';
+
+/**
+ * Create initial GameState from Deck
+ * @param deck - Deck (Map of ID -> NormalizedPrototype)
+ * @returns Initial GameState with shuffled stack and initial tatami
+ */
+export function createInitialState(deck: Deck): Omit<GameState, 'players'> {
+  if (deck.size === 0) {
+    throw new Error('Deck must not be empty');
+  }
+
+  // Get all IDs and shuffle
+  const allIds = getDeckIds(deck);
+  const shuffledIds = shuffle(allIds);
+
+  // Extract first 5 (or less if deck is smaller) for tatami
+  const initialTatamiSize = Math.min(5, shuffledIds.length);
+  const tatamiIds = shuffledIds.slice(0, initialTatamiSize);
+  const remainingStackIds = shuffledIds.slice(initialTatamiSize);
+
+  return {
+    deck,
+    stack: remainingStackIds,
+    tatami: tatamiIds,
+  };
+}

--- a/src/lib/karuta/stack/shuffle.ts
+++ b/src/lib/karuta/stack/shuffle.ts
@@ -1,0 +1,13 @@
+/**
+ * Fisher-Yates shuffle algorithm
+ * @param array - Array to shuffle
+ * @returns Shuffled array (new array, does not mutate original)
+ */
+export function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}

--- a/src/lib/promidas.ts
+++ b/src/lib/promidas.ts
@@ -22,6 +22,7 @@ export async function getPromidasRepository(): Promise<ProtopediaInMemoryReposit
 
   // Initialize snapshot with 100 prototypes
   const result = await repository.setupSnapshot({ limit: 100 });
+  repository.getRandomPrototypeFromSnapshot(); // Warm up
 
   if (!result.ok) {
     throw new Error(`Failed to setup snapshot: ${result.message}`);

--- a/src/models/karuta/deck.ts
+++ b/src/models/karuta/deck.ts
@@ -1,0 +1,40 @@
+import type { NormalizedPrototype } from '@f88/promidas/types';
+
+/**
+ * Deck type - Map of prototype ID to prototype
+ * Ensures unique IDs structurally
+ */
+export type Deck = Map<number, NormalizedPrototype>;
+
+/**
+ * DeckRecipe - Deck generation rule definition
+ */
+export type DeckRecipe = {
+  id: string;
+  title: string;
+  deckSize: number; // Number of YomiFuda-ToriFuda pairs
+};
+
+/**
+ * Prototype IDs hash - reproducible deck identifier
+ * Same ID set = Same hash (ignores fetchedAt)
+ */
+export type DeckIdsHash = string; // SHA-256(prototypeIds)
+
+/**
+ * Deck identifier - uniquely identifies a specific deck at specific time
+ * Includes fetchedAt for complete uniqueness
+ */
+export type DeckIdentifier = {
+  deckHash: string; // SHA-256(fetchedAt + prototypeIds)
+};
+
+/**
+ * Deck metadata - both hashes + regeneration info
+ */
+export type DeckMetaData = DeckIdentifier & {
+  deckIdsHash: DeckIdsHash; // For grouping/regeneration
+  title: string; // Display title (e.g., "3 Races")
+  prototypeIds: number[]; // Sorted IDs for API re-fetch
+  fetchedAt: number; // API fetch timestamp (for records/display)
+};

--- a/src/models/karuta/game.ts
+++ b/src/models/karuta/game.ts
@@ -1,0 +1,39 @@
+import type { Deck, DeckMetaData } from './deck';
+import type { Player } from './player';
+import type { Stack } from './stack';
+import type { Tatami } from './tatami';
+
+/**
+ * GameState - Complete game state
+ */
+export type GameState = {
+  deck: Deck; // ID -> Prototype map
+  stack: Stack; // Remaining card IDs
+  tatami: Tatami; // Shared Tatami card IDs (for Keyboard mode or reference)
+  players: Player[];
+};
+
+/**
+ * Game result - single game outcome
+ */
+export type GameResult = {
+  id: string; // Unique result ID
+  deckMetaData: DeckMetaData;
+  playedAt: number; // Game completion timestamp
+  playTime: number; // Game duration in milliseconds
+  players: {
+    id: string;
+    name: string;
+    score: number;
+    mochiFudaCount: number;
+    wrongCount: number;
+    isWinner: boolean;
+  }[];
+};
+
+/**
+ * Game history - all game results
+ */
+export type GameHistory = {
+  results: GameResult[];
+};

--- a/src/models/karuta/index.ts
+++ b/src/models/karuta/index.ts
@@ -1,0 +1,20 @@
+// Deck types
+export type {
+  Deck,
+  DeckRecipe,
+  DeckIdsHash,
+  DeckIdentifier,
+  DeckMetaData,
+} from './deck';
+
+// Player types
+export type { Player } from './player';
+
+// Stack types
+export type { Stack } from './stack';
+
+// Tatami types
+export type { Tatami } from './tatami';
+
+// Game types
+export type { GameState, GameResult, GameHistory } from './game';

--- a/src/models/karuta/player.ts
+++ b/src/models/karuta/player.ts
@@ -1,0 +1,10 @@
+/**
+ * Player - Player state
+ */
+export type Player = {
+  id: string;
+  name: string;
+  tatami: number[]; // Player's own Tatami (required for Touch mode)
+  mochiFuda: number[]; // IDs of acquired cards
+  score: number;
+};

--- a/src/models/karuta/stack.ts
+++ b/src/models/karuta/stack.ts
@@ -1,0 +1,5 @@
+/**
+ * Stack - Prototype IDs waiting to be drawn to Tatami
+ * Represents the deck of cards yet to be played
+ */
+export type Stack = number[];

--- a/src/models/karuta/tatami.ts
+++ b/src/models/karuta/tatami.ts
@@ -1,0 +1,5 @@
+/**
+ * Tatami - Prototype IDs currently in play
+ * Represents the cards placed on the playing field
+ */
+export type Tatami = number[];


### PR DESCRIPTION
## Overview

This PR reorganizes the karuta data models and implementation structure to improve maintainability and prepare for multi-player support.

## Changes

### Type Definitions (models/karuta/)
- **Split monolithic types** into separate files for better organization:
  - `deck.ts`: Deck, DeckRecipe, DeckIdentifier, DeckMetaData, DeckIdsHash
  - `player.ts`: Player type
  - `stack.ts`: Stack type
  - `tatami.ts`: Tatami type
  - `game.ts`: GameState, GameResult, GameHistory
  - `index.ts`: Unified exports

### Implementation (lib/karuta/)
- **Organized into domain-specific directories:**
  - `deck/`: Deck utilities (hash, accessor, utils)
  - `recipe/`: Recipe definitions and deck generation
  - `stack/`: Stack initialization and shuffle
  - `dummy-data.ts`: Faker-based dummy data generation

### Key Improvements
- **Deck as Map<number, NormalizedPrototype>**: Ensures ID uniqueness structurally
- **Dual hash system**: 
  - `deckHash`: Unique per fetch (includes fetchedAt)
  - `deckIdsHash`: Reproducible (prototypeIds only) for deck regeneration
- **Concept separation**: Stack and Tatami are now separate types
- **Removed redundant fields**: `totalRaces` and `currentRace` (derivable from other state)

### Components
- **RecipeSelector**: BOX selection screen
- **TatamiView**: Main game screen
- **GameResults**: Results screen with replay functionality
- **AppContainer/Presentation**: Root components following Container/Presentational pattern

### Documentation
- Added `DESIGN.md` documenting game rules and architecture

## Testing
- ✅ Type checks passing
- ✅ Basic game flow working (select recipe → play → results → replay)

## Next Steps
- Player initialization logic
- Multi-player support (2-4 players)
- Keyboard/Touch input modes
- GameHistory management with localStorage