### PR TITLE
chore(deps): upgrade promidas to v1.1.0 and promidas-utils to v1.0.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ VITE_UI_DEBUG=false
 # Recommended: Use project-root relative path starting with /
 # Example: /scripts/dev/dev-snapshot-20260114-015905-5938.json
 #
-# Allowed: Relative path (e.g., scripts/dev/...) or file name only (e.g., dev-snapshot-xxx.json)
-# Forbidden: OS absolute paths (e.g., /Users/name/...) are NOT accessible in browser
+# Allowed formats:
+#   - /scripts/dev/dev-snapshot-xxx.json (recommended, root-relative with /)
+#   - scripts/dev/dev-snapshot-xxx.json  (also works, will be normalized)
+#
+# Forbidden formats:
+#   - File name only (e.g., dev-snapshot-xxx.json) - too ambiguous
+#   - OS absolute paths (e.g., /Users/name/...) - not accessible in browser
 # VITE_DEV_SNAPSHOT_PATH=/scripts/dev/dev-snapshot-20260114-015905-5938.json

--- a/.env.example
+++ b/.env.example
@@ -37,13 +37,6 @@ VITE_RANDOM_YOMIFUDA=true
 # Development settings
 # ------------------------------
 
-# Use dummy data instead of API (for development)
-# Set to 'true' to use faker-generated dummy data
-# Set to 'false' to use PROMIDAS API
-# Default: false
-VITE_USE_DUMMY_DATA=false
-# VITE_USE_DUMMY_DATA=true
-
 # Enable debug mode to show additional information in UI
 # Set to 'true' to show API parameters and other debug info
 # Warning: This mode may break layout with verbose information

--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,15 @@ VITE_UI_DEBUG=false
 # VITE_USE_DEV_SNAPSHOT=false
 #VITE_USE_DEV_SNAPSHOT=true
 
-# Path to development snapshot file (absolute path or URL in dev server)
+# Path to development snapshot file
+#
 # Used when VITE_USE_DEV_SNAPSHOT=true
 # Generate snapshot with: npm run generate-snapshot
 # Output location: scripts/dev/dev-snapshot-{timestamp}-{count}.json
+#
+# Recommended: Use project-root relative path starting with /
 # Example: /scripts/dev/dev-snapshot-20260114-015905-5938.json
+#
+# Allowed: Relative path (e.g., scripts/dev/...) or file name only (e.g., dev-snapshot-xxx.json)
+# Forbidden: OS absolute paths (e.g., /Users/name/...) are NOT accessible in browser
 # VITE_DEV_SNAPSHOT_PATH=/scripts/dev/dev-snapshot-20260114-015905-5938.json

--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,13 @@ VITE_PROMIDAS_LOG_LEVEL=info
 #VITE_PROMIDAS_LOG_LEVEL=debug
 
 # ------------------------------
-# Game settings
+# App settings
 # ------------------------------
+
+# Application Log Level
+# Options: debug | info | warn | error
+# Default: info
+VITE_LOG_LEVEL=info
 
 # Randomly pick YomiFuda from tatami
 # Set to 'true' to randomly select YomiFuda (makes game more challenging)
@@ -50,3 +55,21 @@ VITE_DEBUG_MODE=false
 # Default: false
 VITE_UI_DEBUG=false
 #VITE_UI_DEBUG=true
+
+# ------------------------------
+# Development snapshot
+# ------------------------------
+
+# Use development snapshot instead of API
+# Set to 'true' to load data from local snapshot file (offline development)
+# Set to 'false' to use ProtoPedia API (requires valid token)
+# Default: false
+# VITE_USE_DEV_SNAPSHOT=false
+#VITE_USE_DEV_SNAPSHOT=true
+
+# Path to development snapshot file (absolute path or URL in dev server)
+# Used when VITE_USE_DEV_SNAPSHOT=true
+# Generate snapshot with: npm run generate-snapshot
+# Output location: scripts/dev/dev-snapshot-{timestamp}-{count}.json
+# Example: /scripts/dev/dev-snapshot-20260114-015905-5938.json
+# VITE_DEV_SNAPSHOT_PATH=/scripts/dev/dev-snapshot-20260114-015905-5938.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ storybook-static
 # Development
 .coverage
 coverage/
+scripts/dev/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ログレベル制御機能 (`VITE_LOG_LEVEL`)
     - `debug` / `info` (default) / `warn` / `error` のレベルでコンソール出力を制御
 - `index.html` に `<meta name="mobile-web-app-capable" content="yes">` を追加 (deprecated 警告対応)
+- キーボードモード: 畳サイズに応じたキーバインディング変更機能
+    - `GameState` に `tatamiSize` フィールドを追加 (初期設定値を保持)
+    - `getPlayerKeyBindings()` / `getKeyForCard()`: `tatamiSize` パラメータ追加
+    - プレイヤー数2人以下 & 畳サイズ4/8 → 8キーレイアウト
+    - プレイヤー数2人以下 & 畳サイズ12/16 → 16キーレイアウト
+    - プレイヤー数3人以上 → 常に8キーレイアウト
+    - 全てのプレイヤー数(1-4) × 畳サイズ(4,8,12,16)の組み合わせをテスト
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `public/sitemap.xml` - サイト構造を定義するサイトマップ
     - `index.html` に SEO メタタグ (keywords, author, canonical) を追加
     - JSON-LD 構造化データ (Schema.org WebApplication 形式) を追加
+- 開発用スナップショット機能 (`VITE_USE_DEV_SNAPSHOT`)
+    - `scripts/generate-snapshot.ts`: デッキレシピからリポジトリデータ(JSON)を生成するスクリプト
+    - `DeckManager`: 生成されたJSONファイルからデータを読み込む機能 (`import.meta.glob`利用)
+- ログレベル制御機能 (`VITE_LOG_LEVEL`)
+    - `debug` / `info` (default) / `warn` / `error` のレベルでコンソール出力を制御
+- `index.html` に `<meta name="mobile-web-app-capable" content="yes">` を追加 (deprecated 警告対応)
 
 ### Changed
 
 - Upgrade dependencies: `@f88/promidas` from v1.0.0 to v1.1.0
 - Upgrade dependencies: `@f88/promidas-utils` from v0.3.0 to v1.0.0
 - Replace deprecated TanStackRouterVite with tanstackRouter in vite.config.ts
+- Logger (`src/lib/logger.ts`) の実装を刷新
+    - `VITE_DEBUG_MODE` (boolean) への依存を廃止し、`VITE_LOG_LEVEL` (string) に変更
+    - `logger.info` を標準出力に変更 (以前は debug モード時のみ出力)
+- 開発環境設定
+    - `.env.example` に `VITE_LOG_LEVEL` と `VITE_DEV_SNAPSHOT_PATH` の設定例を追加
+
+### Removed
+
+- `VITE_USE_DUMMY_DATA` フラグと関連機能を削除 (Promidas の仕組みへ移行のため)
 
 ## [2026.01.09] - 2026-01-09
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon-180x180.png">
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="PP Karuta" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@vite-pwa/assets-generator": "^1.0.2",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/ui": "^4.0.17",
+        "dotenv": "^17.2.3",
         "eslint": "^9.39.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.26",
@@ -7021,6 +7022,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build-storybook": "storybook build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "generate-snapshot": "tsx scripts/generate-snapshot.ts",
     "generate-pwa-assets": "pwa-assets-generator",
     "deploy": "npm run build && gh-pages -d dist"
   },
@@ -75,6 +76,7 @@
     "@vite-pwa/assets-generator": "^1.0.2",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/ui": "^4.0.17",
+    "dotenv": "^17.2.3",
     "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",

--- a/scripts/generate-snapshot.ts
+++ b/scripts/generate-snapshot.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env tsx
+/**
+ * @fileoverview Generate development snapshot from ProtoPedia API.
+ *
+ * This script fetches prototype data from ProtoPedia API v2 and generates
+ * a serializable snapshot for development use. The snapshot can be loaded
+ * via setupSnapshotFromSerializedData() to enable offline development.
+ *
+ * Usage:
+ *   npm run generate-snapshot
+ *
+ * Environment:
+ *   VITE_PROTOPEDIA_API_V2_TOKEN - Required API token
+ *
+ * Output:
+ *   scripts/dev-snapshot-{timestamp}-{count}.json - Serialized snapshot data
+ */
+
+// Node.js modules
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+// Load environment variables from .env.local
+import { config } from 'dotenv';
+
+// Promidas modules
+import {
+  createPromidasForLocal,
+  ProtopediaInMemoryRepository,
+} from '@f88/promidas';
+import { parseSnapshotOperationFailure } from '@f88/promidas-utils/repository';
+
+// Load .env.local (overrides .env if exists)
+config({
+  path: ['.env.local'],
+  // debug: true,
+});
+
+// Snapshot configuration
+const OFFSET = 0;
+const LIMIT = 10;
+
+/**
+ * Generate output filename with timestamp and count
+ */
+function getOutputPath(count: number): string {
+  const now = new Date();
+  const timestamp = now
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\..+/, '')
+    .replace('T', '-');
+  const filename = `dev-snapshot-${timestamp}-${count}.json`;
+  return resolve(process.cwd(), 'scripts/dev', filename);
+}
+
+async function fetchPrototypeData(
+  repository: ReturnType<typeof createPromidasForLocal>,
+  offset: number,
+  limit: number,
+) {
+  console.log(`\n🌐 Fetching prototypes (offset=${offset}, limit=${limit})...`);
+  const startTime = performance.now();
+  const result = await repository.setupSnapshot({ offset, limit });
+  const elapsed = performance.now() - startTime;
+  if (!result.ok) {
+    console.error('\n❌ Snapshot setup failed:');
+    console.dir(result, { depth: null });
+    const parsed = parseSnapshotOperationFailure(result);
+    console.error(`\n📜 ${parsed?.localizedMessage}`);
+    process.exit(1);
+  }
+  console.log(`✓ Fetched ${result.stats.size} prototypes in ${elapsed.toFixed(0)}ms,
+  Data size: ${(result.stats.dataSizeBytes / 1024).toFixed(1)} KB
+`);
+  return result.stats;
+}
+
+/**
+ * Save snapshot to JSON file
+ *
+ * @param repository - Promidas repository instance
+ * @param prototypeCount - Number of prototypes in the snapshot (for filename)
+ */
+function saveSnapshotToFile(repository: ProtopediaInMemoryRepository) {
+  // Get serializable snapshot
+  console.log('📦 Creating serializable snapshot...');
+  const snapshot = repository.getSerializableSnapshot();
+  if (!snapshot) {
+    console.error('❌ Failed to get serializable snapshot');
+    process.exit(1);
+  }
+  console.log(`✓ Snapshot created
+  Version: ${snapshot.version}
+  Timestamp: ${snapshot.serializedAt}
+  Prototypes: ${snapshot.prototypes.length}
+`);
+
+  // Generate output path with count and timestamp
+  const outputPath = getOutputPath(snapshot.prototypes.length);
+  const outputDir = dirname(outputPath);
+  // Ensure output directory exists
+  if (!existsSync(outputDir)) {
+    console.log(`📁 Creating output directory: ${outputDir}`);
+    mkdirSync(outputDir, { recursive: true });
+    console.log(`✓ Directory created\n`);
+  }
+  // Write snapshot to file
+  console.log(`💾 Writing snapshot to ${outputPath} ...`);
+  const jsonContent = JSON.stringify(snapshot, null, 2);
+  const fileSizeKB = (Buffer.byteLength(jsonContent, 'utf8') / 1024).toFixed(1);
+  writeFileSync(outputPath, jsonContent, 'utf8');
+  console.log(`✓ Snapshot saved (${fileSizeKB} KB)`);
+
+  return outputPath;
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  console.log(`
+🚀 Starting snapshot generation...
+   Limit: ${LIMIT}
+   Offset: ${OFFSET}
+`);
+
+  // Get API token from environment
+  const token = process.env.VITE_PROTOPEDIA_API_V2_TOKEN ?? 'no-token';
+
+  // Create repository
+  console.log('⚙️ Creating repository...');
+  const repository = createPromidasForLocal({
+    protopediaApiToken: token,
+    // logLevel: 'info',
+    logLevel: 'warn',
+  });
+  console.log('✓ Repository created');
+
+  // Fetch prototype data from API
+  await fetchPrototypeData(repository, OFFSET, LIMIT);
+
+  // Save snapshot to file
+  const outputPath = saveSnapshotToFile(repository);
+
+  // Cleanup
+  repository.dispose();
+
+  console.log('\n✅ Snapshot generation completed successfully!');
+  console.log(`   File: ${outputPath}`);
+}
+
+// Execute main function
+main().catch((error) => {
+  console.error('\n❌ Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/generate-snapshot.ts
+++ b/scripts/generate-snapshot.ts
@@ -61,7 +61,10 @@ async function fetchPrototypeData(
 ) {
   console.log(`\n🌐 Fetching prototypes (offset=${offset}, limit=${limit})...`);
   const startTime = performance.now();
-  const result = await repository.setupSnapshot({ offset, limit });
+  const result = await repository.setupSnapshot({
+    offset,
+    limit,
+  });
   const elapsed = performance.now() - startTime;
   if (!result.ok) {
     console.error('\n❌ Snapshot setup failed:');
@@ -70,8 +73,7 @@ async function fetchPrototypeData(
     console.error(`\n📜 ${parsed?.localizedMessage}`);
     process.exit(1);
   }
-  console.log(`✓ Fetched ${result.stats.size} prototypes in ${elapsed.toFixed(0)}ms,
-  Data size: ${(result.stats.dataSizeBytes / 1024).toFixed(1)} KB
+  console.log(`✓ Fetched ${result.stats.size} prototypes in ${elapsed.toFixed(0)}ms, Data size: ${(result.stats.dataSizeBytes / 1024).toFixed(1)} KB
 `);
   return result.stats;
 }
@@ -139,6 +141,7 @@ async function main() {
 
   // Fetch prototype data from API
   await fetchPrototypeData(repository, OFFSET, LIMIT);
+  console.log(repository.analyzePrototypes());
 
   // Save snapshot to file
   const outputPath = saveSnapshotToFile(repository);

--- a/src/components/layout/repo-setup-dialog.tsx
+++ b/src/components/layout/repo-setup-dialog.tsx
@@ -29,9 +29,6 @@ export function RepoSetupDialog({
   useEffect(() => {
     if (!open || !autoCloseOnValid) return;
 
-    const useDummyData = import.meta.env.VITE_USE_DUMMY_DATA === 'true';
-    if (useDummyData) return;
-
     const intervalId = setInterval(() => {
       const repoState = promidasRepositoryManager.getState();
       logger.debug('[RepoSetupDialog] Checking repo state:', repoState);

--- a/src/components/promidas/promidas-repo-dashboard-container.tsx
+++ b/src/components/promidas/promidas-repo-dashboard-container.tsx
@@ -20,8 +20,6 @@ export function PromidasRepoDashboard({
   const [repoError, setRepoError] = useState<string | null>(null);
   const { storeState, stats } = usePromidasStoreState();
 
-  const useDummyData = import.meta.env.VITE_USE_DUMMY_DATA === 'true';
-
   useEffect(() => {
     const updateRepoState = () => {
       const status = promidasRepositoryManager.getState();
@@ -42,7 +40,6 @@ export function PromidasRepoDashboard({
       repoError={repoError}
       storeState={storeState}
       storeStats={stats}
-      useDummyData={useDummyData}
       screenSize={screenSize}
     />
   );

--- a/src/components/promidas/promidas-repo-dashboard-presentation.stories.tsx
+++ b/src/components/promidas/promidas-repo-dashboard-presentation.stories.tsx
@@ -18,23 +18,11 @@ const meta = {
       control: 'select',
       options: ['not-stored', 'stored', 'expired'],
     },
-    useDummyData: { control: 'boolean' },
   },
 } satisfies Meta<typeof PromidasRepoDashboardPresentation>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-export const DummyMode: Story = {
-  args: {
-    screenSize: 'pc',
-    repoState: { type: 'not-created' },
-    repoError: null,
-    storeState: 'not-stored',
-    storeStats: null,
-    useDummyData: true,
-  },
-};
 
 export const NotCreated: Story = {
   args: {
@@ -43,7 +31,6 @@ export const NotCreated: Story = {
     repoError: null,
     storeState: 'not-stored',
     storeStats: null,
-    useDummyData: false,
   },
 };
 
@@ -57,7 +44,6 @@ export const TokenInvalid: Story = {
     repoError: 'Invalid token',
     storeState: 'not-stored',
     storeStats: null,
-    useDummyData: false,
   },
 };
 
@@ -68,7 +54,6 @@ export const ValidWithNotStored: Story = {
     repoError: null,
     storeState: 'not-stored',
     storeStats: null,
-    useDummyData: false,
   },
 };
 
@@ -86,7 +71,6 @@ export const ValidWithStored: Story = {
       isExpired: false,
       refreshInFlight: false,
     },
-    useDummyData: false,
   },
 };
 
@@ -104,7 +88,6 @@ export const ValidWithExpired: Story = {
       isExpired: true,
       refreshInFlight: false,
     },
-    useDummyData: false,
   },
 };
 
@@ -122,7 +105,6 @@ export const LargeDataset: Story = {
       isExpired: false,
       refreshInFlight: false,
     },
-    useDummyData: false,
   },
 };
 
@@ -140,6 +122,5 @@ export const ShortRemainingTime: Story = {
       isExpired: false,
       refreshInFlight: false,
     },
-    useDummyData: false,
   },
 };

--- a/src/components/promidas/promidas-repo-dashboard-presentation.tsx
+++ b/src/components/promidas/promidas-repo-dashboard-presentation.tsx
@@ -17,7 +17,6 @@ export interface PromidasRepoDashboardPresentationProps {
   repoError: string | null;
   storeState: StoreState;
   storeStats: PrototypeInMemoryStats | null;
-  useDummyData: boolean;
   screenSize: ScreenSize;
 }
 
@@ -26,7 +25,6 @@ export function PromidasRepoDashboardPresentation({
   repoError,
   storeState,
   storeStats,
-  useDummyData,
   screenSize,
 }: PromidasRepoDashboardPresentationProps) {
   const styles = getResponsiveStyles(screenSize, {
@@ -134,27 +132,6 @@ export function PromidasRepoDashboardPresentation({
     }
     return `${seconds}秒`;
   };
-
-  if (useDummyData) {
-    return (
-      <Card className="w-full max-w-md">
-        <CardHeader className={styles.padding}>
-          <CardTitle className={styles.title.size}>
-            PROMIDAS Repository
-          </CardTitle>
-          <CardDescription className={styles.text.size}>
-            ダミーデータモード
-          </CardDescription>
-        </CardHeader>
-        <CardContent className={styles.padding}>
-          <p className={`text-muted-foreground ${styles.text.size}`}>
-            環境変数 VITE_USE_DUMMY_DATA=true のため、
-            実際のRepositoryは使用されていません。
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
 
   return (
     <Card className="w-full max-w-md">

--- a/src/components/tatami/player-area.tsx
+++ b/src/components/tatami/player-area.tsx
@@ -95,6 +95,7 @@ export type PlayerAreaProps = {
   playMode: PlayMode;
   feedbackState?: 'correct' | 'incorrect' | null;
   screenSize?: ScreenSize;
+  tatamiSize: number;
 };
 
 export function PlayerArea({
@@ -108,6 +109,7 @@ export function PlayerArea({
   playMode,
   feedbackState = null,
   screenSize = 'pc',
+  tatamiSize,
 }: PlayerAreaProps) {
   const styles = getResponsiveStyles(screenSize, {
     smartphone: {
@@ -217,6 +219,7 @@ export function PlayerArea({
           playerIndex={playerIndex}
           playerCount={playerCount}
           screenSize={screenSize}
+          tatamiSize={tatamiSize}
         />
       </CardContent>
     </Card>

--- a/src/components/tatami/player-tatami.tsx
+++ b/src/components/tatami/player-tatami.tsx
@@ -12,6 +12,7 @@ export type PlayerTatamiProps = {
   playerIndex: number;
   playerCount: number;
   screenSize?: ScreenSize;
+  tatamiSize: number;
 };
 
 export function PlayerTatami({
@@ -21,6 +22,7 @@ export function PlayerTatami({
   playerIndex,
   playerCount,
   screenSize = 'pc',
+  tatamiSize,
 }: PlayerTatamiProps) {
   const styles = getResponsiveStyles(screenSize, {
     smartphone: {
@@ -87,7 +89,12 @@ export function PlayerTatami({
               playMode={playMode}
               showImage={showImage}
               onClick={onCardClick}
-              keyboardKey={getKeyForCard(playerIndex, index, playerCount)}
+              keyboardKey={getKeyForCard(
+                playerIndex,
+                index,
+                playerCount,
+                tatamiSize,
+              )}
               screenSize={screenSize}
             />
           ))}

--- a/src/components/tatami/tatami-view-container.tsx
+++ b/src/components/tatami/tatami-view-container.tsx
@@ -100,6 +100,7 @@ export function TatamiViewContainer({
     playerStates: gameState.playerStates,
     deck: gameState.deck,
     onCardSelect: handlePlayerCardSelect,
+    tatamiSize: gameState.tatamiSize,
   });
 
   // Check if game is complete
@@ -121,6 +122,7 @@ export function TatamiViewContainer({
       onPlayerCardSelect={handlePlayerCardSelect}
       playerFeedbackStates={playerFeedbackStates}
       screenSize={screenSize}
+      tatamiSize={gameState.tatamiSize}
     />
   );
 }

--- a/src/components/tatami/tatami-view-presentation.tsx
+++ b/src/components/tatami/tatami-view-presentation.tsx
@@ -25,6 +25,7 @@ export type TatamiViewPresentationProps = {
   onPlayerCardSelect: (playerId: string, card: NormalizedPrototype) => void;
   playerFeedbackStates: Record<string, 'correct' | 'incorrect' | null>;
   screenSize?: ScreenSize;
+  tatamiSize: number;
 };
 
 export function TatamiViewPresentation({
@@ -39,6 +40,7 @@ export function TatamiViewPresentation({
   onPlayerCardSelect,
   playerFeedbackStates,
   screenSize,
+  tatamiSize,
 }: TatamiViewPresentationProps) {
   // Calculate total stats from all players
   const totalScore = playerStates.reduce((sum, ps) => sum + ps.score, 0);
@@ -218,6 +220,7 @@ export function TatamiViewPresentation({
                         playerFeedbackStates[playerState.player.id] ?? null
                       }
                       screenSize={screenSize}
+                      tatamiSize={tatamiSize}
                     />
                   </div>
                 );

--- a/src/hooks/use-keyboard-card-selection.ts
+++ b/src/hooks/use-keyboard-card-selection.ts
@@ -30,7 +30,7 @@ export function useKeyboardCardSelection({
 
       const key = event.key.toLowerCase();
 
-      // Player count for backward compatibility (not used for key selection anymore)
+// For 1-2 players, key bindings depend on tatamiSize. For 3+ players, an 8-key layout is always used.
       const playerCount = playerStates.length;
 
       // Find which player and card index this key corresponds to

--- a/src/hooks/use-keyboard-card-selection.ts
+++ b/src/hooks/use-keyboard-card-selection.ts
@@ -9,6 +9,7 @@ type UseKeyboardCardSelectionProps = {
   playerStates: GamePlayerState[];
   deck: Map<number, NormalizedPrototype>;
   onCardSelect: (playerId: string, card: NormalizedPrototype) => void;
+  tatamiSize: number;
 };
 
 export function useKeyboardCardSelection({
@@ -16,6 +17,7 @@ export function useKeyboardCardSelection({
   playerStates,
   deck,
   onCardSelect,
+  tatamiSize,
 }: UseKeyboardCardSelectionProps) {
   useEffect(() => {
     if (!enabled) return;
@@ -28,7 +30,7 @@ export function useKeyboardCardSelection({
 
       const key = event.key.toLowerCase();
 
-      // Player count determines key bindings (1-2: 16 keys, 3-4: 8 keys)
+      // Player count for backward compatibility (not used for key selection anymore)
       const playerCount = playerStates.length;
 
       // Find which player and card index this key corresponds to
@@ -38,7 +40,11 @@ export function useKeyboardCardSelection({
         playerIndex++
       ) {
         const playerState = playerStates[playerIndex];
-        const keyBindings = getPlayerKeyBindings(playerIndex, playerCount);
+        const keyBindings = getPlayerKeyBindings(
+          playerIndex,
+          playerCount,
+          tatamiSize,
+        );
 
         if (!keyBindings) continue;
 
@@ -67,5 +73,5 @@ export function useKeyboardCardSelection({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [enabled, playerStates, deck, onCardSelect]);
+  }, [enabled, playerStates, deck, onCardSelect, tatamiSize]);
 }

--- a/src/lib/karuta/deck/deck-manager.ts
+++ b/src/lib/karuta/deck/deck-manager.ts
@@ -29,8 +29,6 @@ import type { NormalizedPrototype } from '@f88/promidas/types';
  * All methods are static as this class serves as a utility namespace.
  */
 export class DeckManager {
-  // ==================== Generation ====================
-
   /**
    * Loads snapshot from development snapshot file.
    *
@@ -61,21 +59,26 @@ export class DeckManager {
     logger.info(`[DEV] Loading snapshot from: ${snapshotPath}`);
 
     try {
-      // Use import.meta.glob to allow Vite to bundle/serve these files correctly
-      // This is safer than fully dynamic imports which can fail in Vite
+      // 1. Identify available snapshot files using Vite's glob import
+      // Vite cannot analyze fully dynamic imports like `import(variable)`.
+      // We must use import.meta.glob to explicitly tell Vite which files to include in the bundle/server.
       const snapshots = import.meta.glob('/scripts/dev/*.json');
 
-      // Normalize path to match glob keys (ensure leading /)
+      // 2. Normalize user-provided path to match Vite's glob keys
+      // Glob keys are typically root-relative (e.g., "/scripts/dev/foo.json").
       const lookupPath = snapshotPath.startsWith('/')
         ? snapshotPath
         : `/${snapshotPath}`;
 
+      // 3. Try to find an exact match first
       const loader = snapshots[lookupPath];
 
       if (!loader) {
-        // Fallback: try fuzzier match if exact match fails
-        // e.g. if user supplied 'scripts/dev/foo.json' but key is '/scripts/dev/foo.json'
-        // or relative paths
+        // 4. Fallback search (Fuzzy matching)
+        // If exact match fails, search for a key that ends with the provided path.
+        // This handles cases where:
+        // - User provided "scripts/dev/foo.json" but key is "/scripts/dev/foo.json"
+        // - User provided relative path "dev-snapshot-xxx.json"
         const foundKey = Object.keys(snapshots).find(
           (key) =>
             key.endsWith(snapshotPath) ||
@@ -85,8 +88,13 @@ export class DeckManager {
 
         if (foundKey) {
           logger.info(`[DEV] Resolved snapshot path to: ${foundKey}`);
+
+          // Execute the loader to import the JSON module
           const module = (await snapshots[foundKey]()) as { default: unknown };
           const snapshot = module.default;
+
+          // Initialize repository with loaded data
+          // Cast is necessary because dynamically imported JSON is 'unknown'
           const result = repository.setupSnapshotFromSerializedData(
             snapshot as unknown as SerializableSnapshot,
           );
@@ -102,11 +110,13 @@ export class DeckManager {
           return result;
         }
 
+        // No match found in available glob results
         throw new Error(
           `Snapshot file not found in glob results. Available: ${Object.keys(snapshots).join(', ')}`,
         );
       }
 
+      // 5. Exact match found - Import and load
       const module = (await loader()) as { default: unknown };
       const snapshot = module.default;
 

--- a/src/lib/karuta/deck/deck-manager.ts
+++ b/src/lib/karuta/deck/deck-manager.ts
@@ -69,6 +69,8 @@ export class DeckManager {
       // 1. Identify available snapshot files using Vite's glob import
       // Vite cannot analyze fully dynamic imports like `import(variable)`.
       // We must use import.meta.glob to explicitly tell Vite which files to include in the bundle/server.
+      // Note: import.meta.glob always bundles matched files regardless of eagerness.
+      // To completely exclude snapshots from production builds, ensure VITE_USE_DEV_SNAPSHOT=false
       const snapshots = import.meta.glob('/scripts/dev/*.json');
 
       // 2. Normalize user-provided path to match Vite's glob keys

--- a/src/lib/karuta/deck/deck-manager.ts
+++ b/src/lib/karuta/deck/deck-manager.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/models/karuta';
 import type { ProtopediaInMemoryRepository } from '@f88/promidas';
 import type { SnapshotOperationResult } from '@f88/promidas/repository';
+import type { SerializableSnapshot } from '@f88/promidas/repository/types';
 import type { NormalizedPrototype } from '@f88/promidas/types';
 
 /**
@@ -31,22 +32,137 @@ export class DeckManager {
   // ==================== Generation ====================
 
   /**
-   * Sets up repository snapshot from DeckRecipe without fetching data.
+   * Loads snapshot from development snapshot file.
    *
-   * Prepares the repository snapshot using the recipe's API parameters
+   * Reads the snapshot file path from VITE_DEV_SNAPSHOT_PATH environment variable,
+   * dynamically imports the JSON file, and sets up the repository with the serialized data.
+   *
+   * This is a development-only utility for offline development without API access.
+   *
+   * **Important**: This method loads the entire snapshot file content regardless of
+   * recipe.apiParams. Any filtering parameters (offset, limit, tags, etc.) specified
+   * in the recipe are ignored. The snapshot file determines what data is loaded.
+   *
+   * @param repository - ProtopediaInMemoryRepository instance to load snapshot into
+   * @returns SnapshotOperationResult indicating success/failure with stats or error details
+   * @throws {Error} If VITE_DEV_SNAPSHOT_PATH is not set
+   * @throws {Error} If snapshot file cannot be loaded or parsed
+   * @private
+   */
+  private static async loadSnapshotFromFile(
+    repository: ProtopediaInMemoryRepository,
+  ): Promise<SnapshotOperationResult> {
+    const snapshotPath = import.meta.env.VITE_DEV_SNAPSHOT_PATH;
+    if (!snapshotPath || snapshotPath.trim() === '') {
+      throw new Error(
+        'VITE_DEV_SNAPSHOT_PATH is not set or empty. Please specify snapshot file path.',
+      );
+    }
+    logger.info(`[DEV] Loading snapshot from: ${snapshotPath}`);
+
+    try {
+      // Use import.meta.glob to allow Vite to bundle/serve these files correctly
+      // This is safer than fully dynamic imports which can fail in Vite
+      const snapshots = import.meta.glob('/scripts/dev/*.json');
+
+      // Normalize path to match glob keys (ensure leading /)
+      const lookupPath = snapshotPath.startsWith('/')
+        ? snapshotPath
+        : `/${snapshotPath}`;
+
+      const loader = snapshots[lookupPath];
+
+      if (!loader) {
+        // Fallback: try fuzzier match if exact match fails
+        // e.g. if user supplied 'scripts/dev/foo.json' but key is '/scripts/dev/foo.json'
+        // or relative paths
+        const foundKey = Object.keys(snapshots).find(
+          (key) =>
+            key.endsWith(snapshotPath) ||
+            key === snapshotPath ||
+            key === `/${snapshotPath}`,
+        );
+
+        if (foundKey) {
+          logger.info(`[DEV] Resolved snapshot path to: ${foundKey}`);
+          const module = (await snapshots[foundKey]()) as { default: unknown };
+          const snapshot = module.default;
+          const result = repository.setupSnapshotFromSerializedData(
+            snapshot as unknown as SerializableSnapshot,
+          );
+
+          if (!result.ok) {
+            logger.error(`[DEV] Snapshot validation failed: ${result.message}`);
+            throw new Error(`Snapshot validation failed: ${result.message}`);
+          }
+
+          logger.info(
+            `[DEV] Snapshot loaded successfully: ${result.stats.size} prototypes`,
+          );
+          return result;
+        }
+
+        throw new Error(
+          `Snapshot file not found in glob results. Available: ${Object.keys(snapshots).join(', ')}`,
+        );
+      }
+
+      const module = (await loader()) as { default: unknown };
+      const snapshot = module.default;
+
+      const result = repository.setupSnapshotFromSerializedData(
+        snapshot as unknown as SerializableSnapshot,
+      );
+
+      if (!result.ok) {
+        logger.error(`[DEV] Snapshot validation failed: ${result.message}`);
+        throw new Error(`Snapshot validation failed: ${result.message}`);
+      }
+
+      logger.info(
+        `[DEV] Snapshot loaded successfully: ${result.stats.size} prototypes`,
+      );
+
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[DEV] Failed to load snapshot: ${message}`);
+      throw new Error(
+        `Failed to load snapshot from ${snapshotPath}: ${message}`,
+      );
+    }
+  }
+
+  /**
+   * Sets up repository snapshot from DeckRecipe or development snapshot file.
+   *
+   * In development snapshot mode (VITE_USE_DEV_SNAPSHOT=true), loads pre-generated
+   * snapshot from local file specified in VITE_DEV_SNAPSHOT_PATH.
+   * In normal mode, prepares the repository snapshot using the recipe's API parameters
    * but does not retrieve the actual prototype data. This is useful for
    * staged loading or when you want to verify API parameters before fetching.
    *
    * @param recipe - DeckRecipe containing apiParams for repository query
    * @param repository - ProtopediaInMemoryRepository instance for snapshot setup
    * @returns SnapshotOperationResult indicating success/failure with stats or error details
-   * @throws {Error} If recipe is invalid or missing apiParams
+   * @throws {Error} If recipe is invalid or missing apiParams (normal mode)
+   * @throws {Error} If snapshot file cannot be loaded (dev snapshot mode)
    * @private
    */
   private static async setupSnapshotFromRecipe(
     recipe: DeckRecipe,
     repository: ProtopediaInMemoryRepository,
   ): Promise<SnapshotOperationResult> {
+    // Development snapshot mode: Load from pre-generated file
+    // Note: recipe.apiParams are ignored in snapshot mode - entire snapshot is loaded
+    if (import.meta.env.VITE_USE_DEV_SNAPSHOT === 'true') {
+      logger.info(
+        '[DEV] Snapshot mode enabled - loading from file (recipe.apiParams will be ignored)',
+      );
+      return this.loadSnapshotFromFile(repository);
+    }
+
+    // Normal mode: Fetch from API using recipe
     // Validation: Recipe
     if (!recipe || !recipe.apiParams) {
       throw new Error(`Invalid recipe: apiParams is required`);

--- a/src/lib/karuta/deck/deck-manager.ts
+++ b/src/lib/karuta/deck/deck-manager.ts
@@ -33,9 +33,15 @@ export class DeckManager {
    * Loads snapshot from development snapshot file.
    *
    * Reads the snapshot file path from VITE_DEV_SNAPSHOT_PATH environment variable,
-   * dynamically imports the JSON file, and sets up the repository with the serialized data.
+   * uses Vite's import.meta.glob to locate available snapshot files, and dynamically
+   * imports the matching JSON file to set up the repository with serialized data.
    *
    * This is a development-only utility for offline development without API access.
+   *
+   * **Path Resolution:**
+   * - Requires project-root relative path (e.g., `/scripts/dev/snapshot.json` or `scripts/dev/snapshot.json`)
+   * - Path is normalized (leading `/` added if missing) and matched exactly against glob results
+   * - File-name-only paths are NOT supported for safety reasons
    *
    * **Important**: This method loads the entire snapshot file content regardless of
    * recipe.apiParams. Any filtering parameters (offset, limit, tags, etc.) specified
@@ -43,8 +49,9 @@ export class DeckManager {
    *
    * @param repository - ProtopediaInMemoryRepository instance to load snapshot into
    * @returns SnapshotOperationResult indicating success/failure with stats or error details
-   * @throws {Error} If VITE_DEV_SNAPSHOT_PATH is not set
-   * @throws {Error} If snapshot file cannot be loaded or parsed
+   * @throws {Error} If VITE_DEV_SNAPSHOT_PATH is not set or empty
+   * @throws {Error} If snapshot file path does not match any available files
+   * @throws {Error} If snapshot file cannot be loaded or validation fails
    * @private
    */
   private static async loadSnapshotFromFile(
@@ -70,53 +77,16 @@ export class DeckManager {
         ? snapshotPath
         : `/${snapshotPath}`;
 
-      // 3. Try to find an exact match first
+      // 3. Find exact match
       const loader = snapshots[lookupPath];
-
       if (!loader) {
-        // 4. Fallback search (Fuzzy matching)
-        // If exact match fails, search for a key that ends with the provided path.
-        // This handles cases where:
-        // - User provided "scripts/dev/foo.json" but key is "/scripts/dev/foo.json"
-        // - User provided relative path "dev-snapshot-xxx.json"
-        const foundKey = Object.keys(snapshots).find(
-          (key) =>
-            key.endsWith(snapshotPath) ||
-            key === snapshotPath ||
-            key === `/${snapshotPath}`,
-        );
-
-        if (foundKey) {
-          logger.info(`[DEV] Resolved snapshot path to: ${foundKey}`);
-
-          // Execute the loader to import the JSON module
-          const module = (await snapshots[foundKey]()) as { default: unknown };
-          const snapshot = module.default;
-
-          // Initialize repository with loaded data
-          // Cast is necessary because dynamically imported JSON is 'unknown'
-          const result = repository.setupSnapshotFromSerializedData(
-            snapshot as unknown as SerializableSnapshot,
-          );
-
-          if (!result.ok) {
-            logger.error(`[DEV] Snapshot validation failed: ${result.message}`);
-            throw new Error(`Snapshot validation failed: ${result.message}`);
-          }
-
-          logger.info(
-            `[DEV] Snapshot loaded successfully: ${result.stats.size} prototypes`,
-          );
-          return result;
-        }
-
         // No match found in available glob results
         throw new Error(
-          `Snapshot file not found in glob results. Available: ${Object.keys(snapshots).join(', ')}`,
+          `Snapshot file not found: ${lookupPath}. Available files: ${Object.keys(snapshots).join(', ')}`,
         );
       }
 
-      // 5. Exact match found - Import and load
+      // 4. Import and load the snapshot
       const module = (await loader()) as { default: unknown };
       const snapshot = module.default;
 

--- a/src/lib/karuta/game/game-manager.ts
+++ b/src/lib/karuta/game/game-manager.ts
@@ -85,6 +85,7 @@ export class GameManager {
       tatami: tatamiIds,
       playerStates,
       totalRaces,
+      tatamiSize: initialTatamiSize,
     };
   }
 

--- a/src/lib/karuta/keyboard-bindings.test.ts
+++ b/src/lib/karuta/keyboard-bindings.test.ts
@@ -126,53 +126,116 @@ describe('keyboard-bindings', () => {
   });
 
   describe('getPlayerKeyBindings', () => {
-    it('should return 16-key bindings for 1 player', () => {
-      const bindings = getPlayerKeyBindings(0, 1);
-      expect(bindings).toEqual(PLAYER_KEY_BINDINGS_16[0]);
-      expect(bindings).toHaveLength(16);
-    });
-
-    it('should return 16-key bindings for 2 players', () => {
-      const bindings0 = getPlayerKeyBindings(0, 2);
-      const bindings1 = getPlayerKeyBindings(1, 2);
-      expect(bindings0).toEqual(PLAYER_KEY_BINDINGS_16[0]);
-      expect(bindings1).toEqual(PLAYER_KEY_BINDINGS_16[1]);
-      expect(bindings0).toHaveLength(16);
-      expect(bindings1).toHaveLength(16);
-    });
-
-    it('should return 8-key bindings for 3 players', () => {
-      const bindings0 = getPlayerKeyBindings(0, 3);
-      const bindings1 = getPlayerKeyBindings(1, 3);
-      const bindings2 = getPlayerKeyBindings(2, 3);
-      expect(bindings0).toEqual(PLAYER_KEY_BINDINGS_8[0]);
-      expect(bindings1).toEqual(PLAYER_KEY_BINDINGS_8[1]);
-      expect(bindings2).toEqual(PLAYER_KEY_BINDINGS_8[2]);
-      expect(bindings0).toHaveLength(8);
-      expect(bindings1).toHaveLength(8);
-      expect(bindings2).toHaveLength(8);
-    });
-
-    it('should return 8-key bindings for 4 players', () => {
-      const bindings0 = getPlayerKeyBindings(0, 4);
-      const bindings1 = getPlayerKeyBindings(1, 4);
-      const bindings2 = getPlayerKeyBindings(2, 4);
-      const bindings3 = getPlayerKeyBindings(3, 4);
-      expect(bindings0).toEqual(PLAYER_KEY_BINDINGS_8[0]);
-      expect(bindings1).toEqual(PLAYER_KEY_BINDINGS_8[1]);
-      expect(bindings2).toEqual(PLAYER_KEY_BINDINGS_8[2]);
-      expect(bindings3).toEqual(PLAYER_KEY_BINDINGS_8[3]);
-      expect(bindings0).toHaveLength(8);
-      expect(bindings1).toHaveLength(8);
-      expect(bindings2).toHaveLength(8);
-      expect(bindings3).toHaveLength(8);
-    });
-
-    it('should default to 2 players (16 keys) when playerCount is not provided', () => {
-      const bindings = getPlayerKeyBindings(0);
-      expect(bindings).toEqual(PLAYER_KEY_BINDINGS_16[0]);
-      expect(bindings).toHaveLength(16);
-    });
+    // Parameterized test for all combinations of playerCount (1,2,3,4) and tatamiSize (4,8,12,16)
+    it.each([
+      // playerCount 1
+      {
+        playerCount: 1,
+        tatamiSize: 4,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 1,
+        tatamiSize: 8,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 1,
+        tatamiSize: 12,
+        expectedLayout: '16-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_16,
+      },
+      {
+        playerCount: 1,
+        tatamiSize: 16,
+        expectedLayout: '16-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_16,
+      },
+      // playerCount 2
+      {
+        playerCount: 2,
+        tatamiSize: 4,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 2,
+        tatamiSize: 8,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 2,
+        tatamiSize: 12,
+        expectedLayout: '16-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_16,
+      },
+      {
+        playerCount: 2,
+        tatamiSize: 16,
+        expectedLayout: '16-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_16,
+      },
+      // playerCount 3 (always 8-key regardless of tatamiSize)
+      {
+        playerCount: 3,
+        tatamiSize: 4,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 3,
+        tatamiSize: 8,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 3,
+        tatamiSize: 12,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 3,
+        tatamiSize: 16,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      // playerCount 4 (always 8-key regardless of tatamiSize)
+      {
+        playerCount: 4,
+        tatamiSize: 4,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 4,
+        tatamiSize: 8,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 4,
+        tatamiSize: 12,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+      {
+        playerCount: 4,
+        tatamiSize: 16,
+        expectedLayout: '8-key',
+        expectedBindings: PLAYER_KEY_BINDINGS_8,
+      },
+    ])(
+      'should return $expectedLayout bindings for playerCount=$playerCount, tatamiSize=$tatamiSize',
+      ({ playerCount, tatamiSize, expectedBindings }) => {
+        const bindings = getPlayerKeyBindings(0, playerCount, tatamiSize);
+        expect(bindings).toEqual(expectedBindings[0]);
+        expect(bindings).toHaveLength(expectedBindings[0].length);
+      },
+    );
 
     it('should return undefined for invalid player index', () => {
       expect(getPlayerKeyBindings(10, 2)).toBeUndefined();
@@ -181,13 +244,13 @@ describe('keyboard-bindings', () => {
   });
 
   describe('getKeyForCard', () => {
-    it('should return correct key for 16-key layout (2 players)', () => {
-      expect(getKeyForCard(0, 0, 2)).toBe('7');
-      expect(getKeyForCard(0, 4, 2)).toBe('u');
-      expect(getKeyForCard(0, 15, 2)).toBe('/');
-      expect(getKeyForCard(1, 0, 2)).toBe('1');
-      expect(getKeyForCard(1, 8, 2)).toBe('a');
-      expect(getKeyForCard(1, 15, 2)).toBe('v');
+    it('should return correct key for 16-key layout (2 players, tatamiSize=16)', () => {
+      expect(getKeyForCard(0, 0, 2, 16)).toBe('7');
+      expect(getKeyForCard(0, 4, 2, 16)).toBe('u');
+      expect(getKeyForCard(0, 15, 2, 16)).toBe('/');
+      expect(getKeyForCard(1, 0, 2, 16)).toBe('1');
+      expect(getKeyForCard(1, 8, 2, 16)).toBe('a');
+      expect(getKeyForCard(1, 15, 2, 16)).toBe('v');
     });
 
     it('should return correct key for 8-key layout (4 players)', () => {
@@ -201,9 +264,9 @@ describe('keyboard-bindings', () => {
       expect(getKeyForCard(3, 7, 4)).toBe('r');
     });
 
-    it('should default to 2 players (16 keys) when playerCount is not provided', () => {
-      expect(getKeyForCard(0, 0)).toBe('7');
-      expect(getKeyForCard(0, 15)).toBe('/');
+    it('should default to 2 players with tatamiSize=8 when parameters are not provided', () => {
+      expect(getKeyForCard(0, 0)).toBe('j');
+      expect(getKeyForCard(0, 7)).toBe('/');
     });
 
     it('should return undefined for invalid card index', () => {

--- a/src/lib/karuta/keyboard-bindings.ts
+++ b/src/lib/karuta/keyboard-bindings.ts
@@ -44,27 +44,48 @@ export const PLAYER_KEY_BINDINGS_8: string[][] = [
 ];
 
 /**
- * Get key bindings for a specific player index based on player count
- * Player count 1-2: Use 16-key layout
- * Player count 3-4: Use 8-key layout
+ * Get key bindings for a specific player index based on tatami size
+ * Tatami size <= 8: Use 8-key layout
+ * Tatami size > 8: Use 16-key layout
+ *
+ * @param playerIndex - Index of the player (0-3)
+ * @param playerCount - Number of players (deprecated, kept for backward compatibility)
+ * @param tatamiSize - Initial tatami size setting (determines key layout)
  */
 export function getPlayerKeyBindings(
   playerIndex: number,
   playerCount: number = 2,
+  tatamiSize: number = 16,
 ): string[] | undefined {
-  const bindings =
-    playerCount >= 3 ? PLAYER_KEY_BINDINGS_8 : PLAYER_KEY_BINDINGS_16;
-  return bindings[playerIndex];
+  if (playerCount <= 2) {
+    switch (tatamiSize) {
+      case 4: {
+        return PLAYER_KEY_BINDINGS_8[playerIndex];
+      }
+      case 8:
+        return PLAYER_KEY_BINDINGS_8[playerIndex];
+      default:
+        return PLAYER_KEY_BINDINGS_16[playerIndex];
+    }
+  } else {
+    return PLAYER_KEY_BINDINGS_8[playerIndex];
+  }
 }
 
 /**
  * Get individual key for a specific card index within a player's tatami
+ *
+ * @param playerIndex - Index of the player (0-3)
+ * @param cardIndex - Index of the card in player's tatami
+ * @param playerCount - Number of players (deprecated, kept for backward compatibility)
+ * @param tatamiSize - Initial tatami size setting (determines key layout)
  */
 export function getKeyForCard(
   playerIndex: number,
   cardIndex: number,
   playerCount: number = 2,
+  tatamiSize: number = 8,
 ): string | undefined {
-  const keys = getPlayerKeyBindings(playerIndex, playerCount);
+  const keys = getPlayerKeyBindings(playerIndex, playerCount, tatamiSize);
   return keys?.[cardIndex];
 }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -22,103 +22,39 @@ describe('logger', () => {
     consoleWarnSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     vi.resetModules();
+    vi.unstubAllEnvs();
   });
 
-  describe('with DEBUG_MODE enabled', () => {
-    beforeEach(async () => {
-      vi.stubEnv('VITE_DEBUG_MODE', 'true');
-      // Reimport logger to pick up the new env value
-      await vi.importActual('@/lib/logger');
+  const loadLogger = async () => {
+    // Force re-import to pick up new env
+    await vi.importActual('@/lib/logger');
+    const { logger } = await import('@/lib/logger');
+    return logger;
+  };
+
+  describe('with LOG_LEVEL = debug', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_LOG_LEVEL', 'debug');
     });
 
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
+    it('should output all logs', async () => {
+      const logger = await loadLogger();
 
-    it('should output debug logs with [DEBUG] prefix', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.debug('test message', { foo: 'bar' });
-      expect(consoleDebugSpy).toHaveBeenCalledWith('[DEBUG]', 'test message', {
-        foo: 'bar',
-      });
-    });
+      logger.debug('debug');
+      expect(consoleDebugSpy).toHaveBeenCalledWith('[DEBUG]', 'debug');
 
-    it('should output info logs with [INFO] prefix', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.info('info message', 123);
-      expect(consoleInfoSpy).toHaveBeenCalledWith(
-        '[INFO]',
-        'info message',
-        123,
-      );
-    });
-  });
+      logger.info('info');
+      expect(consoleInfoSpy).toHaveBeenCalledWith('[INFO]', 'info');
 
-  describe('with DEBUG_MODE disabled', () => {
-    beforeEach(async () => {
-      vi.stubEnv('VITE_DEBUG_MODE', 'false');
-      await vi.importActual('@/lib/logger');
-    });
+      logger.warn('warn');
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[WARN]', 'warn');
 
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
-
-    it('should not output debug logs when DEBUG_MODE is false', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.debug('test message');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
-
-    it('should not output info logs when DEBUG_MODE is false', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.info('info message');
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('always enabled logs', () => {
-    it('should output log messages with [LOG] prefix', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.log('log message', 'data');
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        '[LOG]',
-        'log message',
-        'data',
-      );
-    });
-
-    it('should output warn messages with [WARN] prefix', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.warn('warning message', { code: 404 });
-      expect(consoleWarnSpy).toHaveBeenCalledWith('[WARN]', 'warning message', {
-        code: 404,
-      });
-    });
-
-    it('should output error messages with [ERROR] prefix', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.error('error message', new Error('test'));
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[ERROR]',
-        'error message',
-        expect.any(Error),
-      );
-    });
-  });
-
-  describe('multiple arguments', () => {
-    beforeEach(async () => {
-      vi.stubEnv('VITE_DEBUG_MODE', 'true');
-      await vi.importActual('@/lib/logger');
-    });
-
-    afterEach(() => {
-      vi.unstubAllEnvs();
+      logger.error('error');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[ERROR]', 'error');
     });
 
     it('should handle multiple arguments in debug', async () => {
-      const { logger } = await import('@/lib/logger');
+      const logger = await loadLogger();
       logger.debug('arg1', 'arg2', 'arg3', { obj: true });
       expect(consoleDebugSpy).toHaveBeenCalledWith(
         '[DEBUG]',
@@ -128,15 +64,28 @@ describe('logger', () => {
         { obj: true },
       );
     });
+  });
 
-    it('should handle no arguments', async () => {
-      const { logger } = await import('@/lib/logger');
-      logger.log();
-      expect(consoleLogSpy).toHaveBeenCalledWith('[LOG]');
+  describe('with LOG_LEVEL = info (default)', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_LOG_LEVEL', 'info');
+    });
+
+    it('should output info and above, but NOT debug', async () => {
+      const logger = await loadLogger();
+
+      logger.debug('debug');
+      expect(consoleDebugSpy).not.toHaveBeenCalled();
+
+      logger.info('info');
+      expect(consoleInfoSpy).toHaveBeenCalledWith('[INFO]', 'info');
+
+      logger.warn('warn');
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[WARN]', 'warn');
     });
 
     it('should handle complex objects', async () => {
-      const { logger } = await import('@/lib/logger');
+      const logger = await loadLogger();
       const complexObj = {
         nested: { deep: { value: 123 } },
         array: [1, 2, 3],
@@ -148,6 +97,50 @@ describe('logger', () => {
         'complex',
         complexObj,
       );
+    });
+  });
+
+  describe('with LOG_LEVEL = warn', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_LOG_LEVEL', 'warn');
+    });
+
+    it('should output warn and above, but NOT info/debug', async () => {
+      const logger = await loadLogger();
+
+      logger.debug('debug');
+      expect(consoleDebugSpy).not.toHaveBeenCalled();
+
+      logger.info('info');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+
+      logger.warn('warn');
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[WARN]', 'warn');
+
+      logger.error('error');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[ERROR]', 'error');
+    });
+  });
+
+  describe('with LOG_LEVEL = error', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_LOG_LEVEL', 'error');
+    });
+
+    it('should output only error', async () => {
+      const logger = await loadLogger();
+
+      logger.debug('debug');
+      expect(consoleDebugSpy).not.toHaveBeenCalled();
+
+      logger.info('info');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+
+      logger.warn('warn');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      logger.error('error');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[ERROR]', 'error');
     });
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,59 +1,70 @@
 /**
  * @fileoverview Simple logger utility
  *
- * Provides logging functions that respect VITE_DEBUG_MODE environment variable.
- * Debug logs are only output when VITE_DEBUG_MODE is set to 'true'.
+ * Provides logging functions that respect VITE_LOG_LEVEL environment variable.
+ * Logs are output if their level is equal to or higher than the configured level.
+ * Order: debug < info < warn < error
+ *
+ * Default level: 'info'
  *
  * @module Logger
  */
 
-const DEBUG_MODE = import.meta.env.VITE_DEBUG_MODE === 'true';
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LOG_LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// Parse log level from env, default to 'info'
+const envLevel = (import.meta.env.VITE_LOG_LEVEL as string) || 'info';
+const CURRENT_LEVEL =
+  LOG_LEVELS[envLevel.toLowerCase() as LogLevel] ?? LOG_LEVELS.info;
 
 /**
  * Logger utility for conditional debug output
  */
 export const logger = {
   /**
-   * Log general messages (always shown)
-   * @param args - Arguments to pass to console.log
-   */
-  log: (...args: unknown[]) => {
-    console.log('[LOG]', ...args);
-  },
-
-  /**
    * Log debug messages (only in debug mode)
    * @param args - Arguments to pass to console.debug
    */
   debug: (...args: unknown[]) => {
-    if (DEBUG_MODE) {
+    if (CURRENT_LEVEL <= LOG_LEVELS.debug) {
       console.debug('[DEBUG]', ...args);
     }
   },
 
   /**
-   * Log informational messages (only in debug mode)
+   * Log informational messages
    * @param args - Arguments to pass to console.info
    */
   info: (...args: unknown[]) => {
-    if (DEBUG_MODE) {
+    if (CURRENT_LEVEL <= LOG_LEVELS.info) {
       console.info('[INFO]', ...args);
     }
   },
 
   /**
-   * Log warning messages (always shown)
+   * Log warning messages
    * @param args - Arguments to pass to console.warn
    */
   warn: (...args: unknown[]) => {
-    console.warn('[WARN]', ...args);
+    if (CURRENT_LEVEL <= LOG_LEVELS.warn) {
+      console.warn('[WARN]', ...args);
+    }
   },
 
   /**
-   * Log error messages (always shown)
+   * Log error messages
    * @param args - Arguments to pass to console.error
    */
   error: (...args: unknown[]) => {
-    console.error('[ERROR]', ...args);
+    if (CURRENT_LEVEL <= LOG_LEVELS.error) {
+      console.error('[ERROR]', ...args);
+    }
   },
 };

--- a/src/lib/repository/dummy-repository.ts
+++ b/src/lib/repository/dummy-repository.ts
@@ -4,20 +4,16 @@ import type {
   PrototypeInMemoryStoreConfig,
 } from '@f88/promidas';
 import type { NormalizedPrototype } from '@f88/promidas/types';
-import type { ListPrototypesParams } from 'protopedia-api-v2-client';
 import { EventEmitter } from 'events';
+import type { ListPrototypesParams } from 'protopedia-api-v2-client';
 
 import { logger } from '@/lib/logger';
 import type {
-  SnapshotOperationSuccess,
-  SnapshotOperationFailure,
+  PrototypeAnalysisResult,
+  SerializableSnapshot,
+  SnapshotOperationResult,
 } from '@f88/promidas/repository/types';
-import type { PrototypeAnalysisResult } from '@f88/promidas/repository/types';
 import { generateDummyPrototypes } from './dummy-data';
-
-type SnapshotOperationResult =
-  | SnapshotOperationSuccess
-  | SnapshotOperationFailure;
 
 /**
  * Dummy implementation of ProtopediaInMemoryRepository for development
@@ -45,6 +41,16 @@ export class DummyRepository implements ProtopediaInMemoryRepository {
       `[DummyRepository] Generated 10000 prototypes in ${elapsedMs.toFixed(2)}ms`,
     );
     logger.info('[DummyRepository] Initialized with 10000 dummy prototypes');
+  }
+
+  getSerializableSnapshot(): SerializableSnapshot {
+    throw new Error('Method not implemented.');
+  }
+  setupSnapshotFromSerializedData(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _data: SerializableSnapshot,
+  ): SnapshotOperationResult {
+    throw new Error('Method not implemented.');
   }
 
   getConfig(): Omit<Required<PrototypeInMemoryStoreConfig>, 'logger'> {

--- a/src/lib/repository/promidas-repository-manager.ts
+++ b/src/lib/repository/promidas-repository-manager.ts
@@ -2,14 +2,13 @@
  * @fileoverview Singleton manager for PROMIDAS repository lifecycle and token validation.
  *
  * Provides centralized management of ProtopediaInMemoryRepository instance with comprehensive
- * token validation state tracking. Supports both production API mode and development dummy data mode.
+ * token validation state tracking.
  *
  * Key Features:
  * - Singleton pattern ensuring only one repository instance exists
  * - Four-state lifecycle management (not-created → validating → created-token-valid/token-invalid)
  * - Automatic token validation using minimal API calls
  * - Request deduplication for concurrent repository access
- * - Dummy data mode support via VITE_USE_DUMMY_DATA environment variable
  * - Dependency injection for token storage (testability)
  *
  * State Machine:
@@ -42,7 +41,6 @@ import type { ListPrototypesParams } from 'protopedia-api-v2-client';
 
 import { logger } from '@/lib/logger';
 import { tokenStorage as defaultTokenStorage } from '@/lib/token-storage';
-import { createDummyRepository } from './dummy-repository';
 
 /**
  * Repository state as a discriminated union.
@@ -93,12 +91,10 @@ export type RepositoryState =
  * Architecture:
  * - **Singleton Pattern**: Ensures only one repository instance exists globally
  * - **State Machine**: Manages 4-state lifecycle (not-created → validating → created-token-valid/token-invalid)
- * - **Dual Mode Support**: Seamlessly switches between real API and dummy data modes
  * - **Request Deduplication**: Prevents multiple concurrent initialization attempts
  *
  * Features:
  * - **Token Validation**: Validates API tokens using minimal setupSnapshot({ limit: 0 }) calls
- * - **Dummy Mode**: Development mode with auto-generated test data (VITE_USE_DUMMY_DATA=true)
  * - **Dependency Injection**: Supports custom token storage for testing
  * - **Error Handling**: Provides localized error messages for token validation failures
  * - **Type Safety**: Uses discriminated unions for compile-time state verification
@@ -198,24 +194,9 @@ export class PromidasRepositoryManager {
   }
 
   /**
-   * Checks if dummy data mode is enabled.
-   *
-   * Dummy mode is activated by setting the VITE_USE_DUMMY_DATA environment variable to 'true'.
-   * In dummy mode, the manager creates a DummyRepository with auto-generated test data
-   * instead of connecting to the real ProtoPedia API.
-   *
-   * @returns `true` if VITE_USE_DUMMY_DATA environment variable equals 'true', `false` otherwise
-   * @private
-   */
-  private isDummyMode(): boolean {
-    return import.meta.env.VITE_USE_DUMMY_DATA === 'true';
-  }
-
-  /**
    * Get the current repository state as a discriminated union
    *
-   * Works for both dummy mode and normal mode. State is determined by
-   * internal repository existence and tokenStatus fields.
+   * State is determined by internal repository existence and tokenStatus fields.
    *
    * State determination based on internal state:
    * - `repository === null && tokenStatus === 'not-validated'` → `not-created`
@@ -386,42 +367,18 @@ export class PromidasRepositoryManager {
    * - `this.tokenStatus`: Set to 'valid' (dummy mode skips token validation)
    *
    * **Note**: Dummy mode doesn't require token validation as it uses local test data.
-   *
-   * @returns Cached or newly created DummyRepository instance
-   * @private
-   */
-  private getDummyRepository(): ProtopediaInMemoryRepository {
-    if (!this.repository) {
-      this.repository = createDummyRepository();
-      this.tokenStatus = 'valid';
-      logger.info(
-        '[PromidasRepositoryManager] Created dummy repository (VITE_USE_DUMMY_DATA=true)',
-      );
-    }
-    return this.repository;
-  }
-
   /**
    * Gets or creates a validated repository instance.
    *
    * Returns a cached repository if already validated, otherwise retrieves the token
    * from storage, creates a repository, and validates it through a minimal API call.
    *
-   * Mode Determination:
-   * - **Dummy Mode** (VITE_USE_DUMMY_DATA=true): Returns DummyRepository with test data
-   * - **Normal Mode**: Creates real repository and validates token via ProtoPedia API
-   *
    * Request Deduplication:
    * Concurrent calls to this method receive the same Promise, preventing duplicate
    * initialization attempts and redundant API calls. The `initPromise` field caches
    * the ongoing operation.
    *
-   * Dummy Mode Process:
-   * 1. Check if dummy repository exists → return cached instance
-   * 2. Create DummyRepository and set `tokenStatus = 'valid'`
-   * 3. Return repository immediately (no API validation needed)
-   *
-   * Normal Mode Process:
+   * Process:
    * 1. Check if repository is valid → return cached instance
    * 2. Check if initialization is in progress → return existing promise
    * 3. Retrieve token from storage (throws if missing)
@@ -476,10 +433,6 @@ export class PromidasRepositoryManager {
    */
 
   async getRepository(): Promise<ProtopediaInMemoryRepository> {
-    if (this.isDummyMode()) {
-      return this.getDummyRepository();
-    }
-
     const state = this.getState();
 
     // Return cached repository if already valid

--- a/src/models/karuta/game.ts
+++ b/src/models/karuta/game.ts
@@ -20,6 +20,7 @@ export type GamePlayerState = {
 export type GameState = {
   deck: Deck; // ID -> Prototype map
   totalRaces: number; // Total number of races in this game (fixed at creation)
+  tatamiSize: number; // Initial tatami size setting (fixed at creation, used for keyboard bindings)
   stack: Stack; // Remaining card IDs
   tatami: Tatami; // Shared Tatami card IDs (for Keyboard mode or reference)
   playerStates: GamePlayerState[];

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "ESNext",
     "types": ["node", "vitest/config"],
     "skipLibCheck": true,
@@ -20,7 +20,9 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,8 +91,8 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         globPatterns: ['**/*.{js,css,html,ico,png,jpg,jpeg,svg}'],
         globIgnores: [
-          '**/faker-vendor-*.js',
           '**/ppk26-icon-*.png',
+          '**/dev-snapshot-*.js',
           'images/**',
           'sss/**',
         ],
@@ -111,23 +111,28 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: (id) => {
+          // Debug: Log module IDs containing promidas
+          // if (id.includes('promidas')) {
+            // console.log('Module ID:', id);
+          // }
+
           // Vendor chunks
           if (id.includes('node_modules')) {
             // TanStack Router
             if (id.includes('@tanstack/react-router')) {
               return 'tanstack-router';
             }
+            // Promidas utilities (separate from main promidas)
+            if (id.includes('/@f88/promidas-utils/')) {
+              return 'promidas-utils';
+            }
             // Promidas (large library)
-            if (id.includes('@f88/promidas')) {
+            if (id.includes('/@f88/promidas/')) {
               return 'promidas';
             }
             // API client
             if (id.includes('protopedia-api-v2-client')) {
               return 'api-vendor';
-            }
-            // Faker.js (large dev dependency mistakenly in production)
-            if (id.includes('@faker-js/faker')) {
-              return 'faker-vendor';
             }
             // React core and scheduler (must be together)
             if (


### PR DESCRIPTION
## 変更内容

### 依存関係のアップグレード
- `@f88/promidas`: v1.0.0 → v1.1.0
- `@f88/promidas-utils`: v0.3.0 → v1.0.0

### 主な追加機能
- SEO対策の実装 (robots.txt, sitemap.xml, メタタグ, JSON-LD)
- 開発用スナップショット機能 (`VITE_USE_DEV_SNAPSHOT`)
- ログレベル制御機能 (`VITE_LOG_LEVEL`)
- キーボードモード: 畳サイズに応じたキーバインディング変更機能

### ビルド・設定の最適化
- PWA設定: dev-snapshotファイルをService Workerのprecacheから除外
- ビルド設定: promidas と promidas-utils を個別のチャンクに分離
- TypeScript設定の統一 (tsconfig.node.json)
- GitHub Actions デプロイワークフロー追加

### テスト
- キーボードバインディングの包括的テストを追加 (22 tests → 38 tests)
- 全てのプレイヤー数(1-4) × 畳サイズ(4,8,12,16)の組み合わせをカバー

## Breaking Changes
なし

## 検証
- ✅ すべてのテストがパス
- ✅ ビルドが成功
- ✅ PWA precacheサイズが制限内 (2.2 MB)

## 関連Issue
なし