### PR TITLE
docs: add ProtoPedia CC BY 4.0 attribution (intro page + README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Intro page: add a ProtoPedia data source / CC BY 4.0 attribution line below
+  the title, with links to ProtoPedia and the CC BY 4.0 license.
+- README: add a "Data Source & License" section documenting that the app uses
+  ProtoPedia data retrieved through the ProtoPedia API (v2), and that ProtoPedia
+  applies the CC BY 4.0 license to registered work information by default
+  (English and Japanese).
+
 ## [2026.01.28] - 2026-01-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ Utilities to assist development using PROMIDAS
 - **Prettier** - Code formatter
 - **ESLint 9** - Static analysis
 - **TypeScript ESLint** - Lint rules for TypeScript
+
+## Data Source & License / データ出典とライセンス
+
+### ProtoPedia Data / ProtoPedia のデータ
+
+This application uses data from [ProtoPedia](https://protopedia.net/), retrieved through the [ProtoPedia API Ver 2.0](https://protopediav2.docs.apiary.io/).
+ProtoPedia applies the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.en) license to registered work information by default.
+
+本アプリケーションは、[ProtoPedia](https://protopedia.net/)の作品情報を [ProtoPedia API Ver 2.0](https://protopediav2.docs.apiary.io/) を通じて取得し、利用しています。
+ProtoPediaでは、登録作品情報に [クリエイティブ・コモンズ 表示 4.0 国際(CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.ja) ライセンスが標準適用されています。
+
+Reference: [ProtoPedia Help Center](https://protopedia.gitbook.io/helpcenter/info/2022.05.23)

--- a/public/data/INTRO.txt
+++ b/public/data/INTRO.txt
@@ -15,6 +15,8 @@ instructions-for-ais:
 
 ProtoPedia Karuta 26 - Bajitoufuu Edition
 
+This site uses data from [ProtoPedia](https://protopedia.net/) ([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/))
+
 ## 🌀 凡人･迷宮入 魔仁亜･即･看破
 
 > **警告:**


### PR DESCRIPTION
## Summary

Add ProtoPedia data attribution so the app meets the CC BY 4.0 attribution
requirement.

- **Intro page** (`public/data/INTRO.txt`): add a line below the title —
  `This site uses data from ProtoPedia (CC BY 4.0)` with links to
  [ProtoPedia](https://protopedia.net/) and the
  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license. The intro
  page is reachable from the main game via the header link ("掟を確認").
- **README** (`## Data Source & License`): document that the app uses ProtoPedia
  data via the ProtoPedia API (v2), and that ProtoPedia applies CC BY 4.0 to
  registered work information by default.

## Notes

- Rendered as Markdown (react-markdown + remark-gfm), so the links work inside
  the existing intro theme; no component/CSS changes needed.
- The protected front-matter and title line of `INTRO.txt` are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)