### PR TITLE
feat(security): add Content Security Policy

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,12 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-  globalIgnores(['dist', 'src/routeTree.gen.ts', '!.storybook']),
+  globalIgnores([
+    'dist',
+    'storybook-static',
+    'src/routeTree.gen.ts',
+    '!.storybook',
+  ]),
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,113 @@ import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+
+/**
+ * Absolute path of the app's own HTML entry point.
+ *
+ * The CSP plugin matches on this rather than on the hook's `path`, so the
+ * guard cannot silently fail open if path normalisation ever changes. A
+ * missing CSP breaks nothing observable, so there would be no symptom.
+ */
+const APP_INDEX_HTML = path.resolve(__dirname, 'index.html');
+
+/**
+ * Builds the Content Security Policy for the given environment.
+ *
+ * The app loads no fonts and embeds no frames, so `default-src 'none'` keeps
+ * both denied. Everything else comes from its own origin, except
+ * protopedia.net, which serves two purposes: it is the sole destination for
+ * the API token, and it hosts the prototype images the game is built around.
+ * The dev server needs a single relaxation: inline scripts for the React
+ * Fast Refresh preamble. Its HMR WebSocket needs no extra source, because
+ * `connect-src 'self'` already matches a ws://
+ * URL on the page's own host and port. Every other directive, `connect-src`
+ * and `img-src` included, is identical in both modes, so exfiltration behaves
+ * the same way in development as in production.
+ *
+ * Delivery differs per environment: GitHub Pages serves static files only and
+ * cannot set response headers, so the production policy travels in a
+ * `<meta http-equiv>` tag. Note that `frame-ancestors`, `report-uri`,
+ * `report-to` and `sandbox` are ignored when delivered that way, and
+ * `Content-Security-Policy-Report-Only` is not available at all.
+ */
+function buildContentSecurityPolicy(
+  mode: 'production' | 'development',
+): string {
+  const isDev = mode === 'development';
+
+  return [
+    // Deny anything not explicitly listed below, including future directives.
+    "default-src 'none'",
+    // Bundled scripts only. Blocks injected inline and remote scripts.
+    // The dev server injects the React Fast Refresh preamble inline, so
+    // 'unsafe-inline' is unavoidable there.
+    `script-src 'self'${isDev ? " 'unsafe-inline'" : ''}`,
+    // react-fast-marquee appends a <style> element at runtime, so inline
+    // styles are unavoidable here.
+    "style-src 'self' 'unsafe-inline'",
+    // Prototype images are served from protopedia.net, which connect-src
+    // already allows, so listing it here opens no new exfiltration channel.
+    // `data:` covers the inline SVG placeholder used as the onError fallback
+    // and issues no network request.
+    "img-src 'self' data: https://protopedia.net",
+    // The single legitimate destination for the API token, in both modes. The
+    // dev server's HMR WebSocket needs no entry of its own: CSP matches a ws://
+    // URL against 'self', so it keeps working through whichever loopback
+    // hostname and port the page was reached on.
+    "connect-src 'self' https://protopedia.net",
+    // The PWA service worker. On CSP Level 3 engines worker-src resolves
+    // through child-src to script-src 'self', which makes this look
+    // redundant. It is not: engines without worker-src support (Safari
+    // before 15.4) fall back to default-src instead, where 'none' blocks
+    // sw.js and silently drops offline support. Listing it also keeps
+    // registration independent of any future script-src tightening.
+    "worker-src 'self'",
+    // The PWA manifest, which falls back to default-src rather than
+    // script-src, so 'none' would block it.
+    "manifest-src 'self'",
+    // No form performs a real submission; the token form calls preventDefault().
+    "form-action 'none'",
+    // Prevents an injected <base> tag from rewriting relative URLs.
+    "base-uri 'none'",
+  ].join('; ');
+}
+
+/**
+ * Injects the CSP meta tag into `index.html` at build time.
+ *
+ * Build-only because the meta tag exists to work around GitHub Pages being
+ * unable to set response headers. The dev server can set them, so it serves the
+ * development policy through `server.headers` instead.
+ */
+function contentSecurityPolicyPlugin(): Plugin {
+  return {
+    name: 'inject-csp-meta',
+    apply: 'build',
+    transformIndexHtml(_html, ctx) {
+      // Storybook's react-vite framework merges this config and builds its own
+      // iframe.html through the same hook. That document needs inline scripts
+      // and framing, so restrict the policy to the app's own entry point.
+      if (ctx.filename !== APP_INDEX_HTML) {
+        return [];
+      }
+
+      return [
+        {
+          tag: 'meta',
+          attrs: {
+            'http-equiv': 'Content-Security-Policy',
+            content: buildContentSecurityPolicy('production'),
+          },
+          // A meta policy only governs what follows it, so it must come first.
+          injectTo: 'head-prepend',
+        },
+      ];
+    },
+  };
+}
 
 export default defineConfig({
   plugins: [
@@ -110,7 +215,22 @@ export default defineConfig({
       gzipSize: true,
       brotliSize: true,
     }),
+    contentSecurityPolicyPlugin(),
   ],
+  server: {
+    // Unlike GitHub Pages, the dev server can set response headers, so the
+    // policy is delivered that way here rather than through the meta tag.
+    headers: {
+      'Content-Security-Policy': buildContentSecurityPolicy('development'),
+    },
+  },
+  preview: {
+    // `vite preview` would otherwise inherit server.headers and serve the
+    // development policy next to the production meta tag. Clearing it keeps
+    // preview a faithful stand-in for GitHub Pages, where the meta tag is the
+    // only policy in effect.
+    headers: {},
+  },
   base: '/pp-karuta/',
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Summary

Adds a Content Security Policy to the app.

The app keeps a ProtoPedia API token in `sessionStorage`, so any code execution can read it. The CSP is defence in depth: it contains the damage rather than preventing the initial compromise.

## What changed

| Commit | Content |
|---|---|
| `feat(security)` | Content Security Policy (`vite.config.ts`) |
| `chore(lint)` | Missing eslint ignore entry for `storybook-static` |

### Content Security Policy

```
default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data: https://protopedia.net; connect-src 'self' https://protopedia.net;
worker-src 'self'; manifest-src 'self'; form-action 'none'; base-uri 'none'
```

- GitHub Pages cannot set response headers, so the production policy travels in a `<meta http-equiv>` tag. That delivery method ignores `frame-ancestors`, `report-uri`, `report-to` and `sandbox`, and Report-Only mode is unavailable.
- The dev server gets the same policy as a real response header, with exactly one relaxation: inline scripts for the React Fast Refresh preamble. `connect-src` and `img-src` are byte-identical across both modes, so exfiltration behaves the same way in development as in production.
- Vite's HMR socket needs no source of its own. CSP matches a `ws://` URL against `'self'`, so the socket connects through whichever loopback hostname and port the page was reached on.
- `preview.headers` is cleared so `vite preview` stops inheriting the dev header and mirrors GitHub Pages, where the meta tag is the only policy in effect.
- Meta injection is limited to the app's own `index.html`, matched by resolved absolute path. Storybook's react-vite framework merges this config and builds its own `iframe.html` through the same hook, which needs inline scripts and framing. Matching the absolute path rather than the hook's `path` keeps the guard from silently failing open: a missing CSP breaks nothing observable, so there would be no symptom.

### Directives specific to this app

`img-src` allows `protopedia.net` because the prototype images are served from there — all 5938 records in a local snapshot resolve to `https://protopedia.net/pic/*`. That origin is already permitted by `connect-src`, so listing it opens no new exfiltration channel. `data:` covers the inline SVG placeholder used as the `onError` fallback and issues no network request.

`worker-src` and `manifest-src` are stated explicitly rather than left to fall back. Without `worker-src`, service worker registration relies on the CSP Level 3 chain `child-src` → `script-src 'self'`, which current Chrome implements but engines predating `worker-src` support (Safari before 15.4) do not — those fall through to `default-src 'none'` and the registration is blocked silently, taking offline support with it. `manifest-src` falls back to `default-src` rather than `script-src`, so `'none'` would block the manifest.

`style-src` needs `'unsafe-inline'` because `react-fast-marquee` appends a `<style>` element at module load time. React's own `style={{}}` prop is not affected, since it goes through the CSSOM API rather than an inline attribute.

### eslint ignore

`storybook-static/` was missing from eslint's ignore list, so running `build-storybook` before `lint` surfaced thousands of errors from generated bundles. `.prettierignore` already excludes the directory, so eslint was the only tool still scanning it. CI is unaffected because it never runs `build-storybook`.

## Verification

Exfiltration attempts were fired at a local nginx container and measured by whether they reached its access log. A CSP-free copy of the same build was served alongside as a control.

| Channel | Without CSP | With CSP |
|---|---|---|
| `fetch()` | reached | **blocked** |
| `new Image().src` | reached | **blocked** |
| `navigator.sendBeacon()` | reached | **blocked** |
| `new WebSocket()` to a local port | reached | **blocked** |
| `location.href` | reached | reached |

Access log totals: 8 lines without the policy, 0 with it. Note that `sendBeacon()` returns `true` even when the request is blocked; only server-side logs reveal what actually went out.

Also confirmed:

- The app renders correctly and a real game was played through in Safari, covering the prototype images and the marquee.
- The service worker registers and reaches `active` under the policy.
- Prototype images from `protopedia.net` load; a real token reaches `/v2/api/prototype/list` with `200` and `access-control-allow-origin: *`.
- HMR stays connected on the dev server, which receives the policy as a response header.
- `build-storybook` output carries no CSP meta in `iframe.html`, and the Storybook dev server receives no CSP header.
- `npm test` passes: 9 files, 216 tests. `typecheck` and `lint` are clean.
- `<meta charset>` sits at byte 422, well inside the 1024-byte requirement.

### One violation is expected

zod probes for JIT support with `new Function("")` inside a `try`/`catch` (`zod/v4/core/util.js`). `script-src 'self'` blocks it, the probe returns `false`, and zod falls back to its interpreted path. Parsing is unaffected and nothing appears in the console. Adding `'unsafe-eval'` to silence it would let injected code use `eval` and `new Function`, which is not a trade worth making.

## Known limitation

**Top-level navigation via `location.href` is not blocked by CSP.** No directive covers it (`navigate-to` was removed from the spec). The follow-on Referer exposure on the destination page remains for the same reason — the sink recorded `Referer: http://localhost:4220/` on the navigation it received.

This PR therefore does not prevent token theft. What it does:

- Downgrades silent, unlimited, continuous exfiltration to a single visible page navigation carrying a few KB.
- Provides the only runtime defence against malicious code bundled through a compromised dependency, which `script-src 'self'` cannot stop because the code ships as first-party JavaScript.

The service worker is a separate execution context, so a meta-delivered policy does not govern it. Preventing code execution in the first place remains the primary control: no XSS sinks, and disciplined dependency management.

## Out of scope

`npm run build-storybook` fails on this branch, but it fails on `main` too: `VitePWA` runs inside the Storybook build and workbox rejects `sb-manager/globals-runtime.js` at 3.25 MB against the precache limit. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
