### PR TITLE
chore(format): apply prettier formatting across the repository

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,11 @@ node_modules/
 # Storybook build
 storybook-static/
 
+# Generated files
+# TanStack Router overwrites this on every route change, and the file itself
+# asks to be excluded from linters and formatters. eslint already ignores it.
+src/routeTree.gen.ts
+
 # Misc
 package-lock.json
 renovate.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Update `promidas` to `^3.0.0`
 - Update `promidas-utils` to `^3.0.0` (compatible with promidas v3)
-- Update various devDependencies (@storybook/*, @tanstack/*, @testing-library/*, etc.)
+- Update various devDependencies (`@storybook/*`, `@tanstack/*`, `@testing-library/*`, etc.)
 
 ## [2026.01.16] - 2026-01-16
 

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -9,7 +9,6 @@ import type { ScreenSize } from '@/types/screen-size';
 import { AppHeaderPresentation } from './app-header-presentation';
 import { RepoStateIndicator } from './repo-state-indicator';
 
-
 interface AppHeaderProps {
   repoState: RepositoryState;
   onRepoIndicatorClick: () => void;

--- a/src/components/layout/repo-setup-dialog.tsx
+++ b/src/components/layout/repo-setup-dialog.tsx
@@ -13,7 +13,6 @@ import type { ScreenSize } from '@/types/screen-size';
 
 import { RepoSetup } from './repo-setup';
 
-
 interface RepoSetupDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;

--- a/src/components/layout/repo-state-indicator.tsx
+++ b/src/components/layout/repo-state-indicator.tsx
@@ -2,7 +2,6 @@ import type { RepositoryState } from '@/lib/repository/promidas-repository-manag
 
 import { RepoStateIndicatorPresentation } from './repo-state-indicator-presentation';
 
-
 interface RepoStateIndicatorProps {
   state: RepositoryState;
   onClick?: () => void;

--- a/src/components/player/player-manager-container.tsx
+++ b/src/components/player/player-manager-container.tsx
@@ -6,7 +6,6 @@ import type { Player } from '@/models/karuta';
 
 import { PlayerManagerPresentation } from './player-manager-presentation';
 
-
 export function PlayerManagerContainer() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/components/promidas/promidas-repo-dashboard-container.tsx
+++ b/src/components/promidas/promidas-repo-dashboard-container.tsx
@@ -9,7 +9,6 @@ import type { ScreenSize } from '@/types/screen-size';
 
 import { PromidasRepoDashboardPresentation } from './promidas-repo-dashboard-presentation';
 
-
 interface PromidasRepoDashboardProps {
   screenSize: ScreenSize;
 }

--- a/src/components/selector/integrated-selector-container.tsx
+++ b/src/components/selector/integrated-selector-container.tsx
@@ -10,7 +10,6 @@ import { logger } from '@/lib/logger';
 
 import { IntegratedSelectorPresentation } from './integrated-selector-presentation';
 
-
 export type IntegratedSelectorContainerProps = {
   setup: UseGameSetupReturn;
   onShowIntro?: () => void;

--- a/src/components/selector/integrated-selector-presentation.tsx
+++ b/src/components/selector/integrated-selector-presentation.tsx
@@ -14,7 +14,6 @@ import { SectionWrapper } from './section-wrapper';
 import { StackRecipeSelector } from './stack-recipe-selector';
 import { TatamiSizeSelector } from './tatami-size-selector';
 
-
 export type IntegratedSelectorPresentationProps = {
   playMode: {
     selected: PlayMode | null;

--- a/src/components/tatami/player-tatami.tsx
+++ b/src/components/tatami/player-tatami.tsx
@@ -5,7 +5,6 @@ import type { ScreenSize } from '@/types/screen-size';
 
 import { ToriFudaCard } from './tori-fuda-card';
 
-
 import type { NormalizedPrototype } from 'promidas/types';
 
 export type PlayerTatamiProps = {

--- a/src/components/tatami/shared-tatami.tsx
+++ b/src/components/tatami/shared-tatami.tsx
@@ -4,7 +4,6 @@ import type { ScreenSize } from '@/types/screen-size';
 
 import { ToriFudaCardTouch } from './tori-fuda-card-touch';
 
-
 import type { NormalizedPrototype } from 'promidas/types';
 
 export type SharedTatamiProps = {

--- a/src/components/tatami/tatami-view-presentation.tsx
+++ b/src/components/tatami/tatami-view-presentation.tsx
@@ -9,7 +9,6 @@ import { PlayerArea } from './player-area';
 import { SharedTatami } from './shared-tatami';
 import { Yomite } from './yomite';
 
-
 import type { NormalizedPrototype } from 'promidas/types';
 
 export type TatamiViewPresentationProps = {

--- a/src/components/tatami/tori-fuda-card.tsx
+++ b/src/components/tatami/tori-fuda-card.tsx
@@ -4,7 +4,6 @@ import type { ScreenSize } from '@/types/screen-size';
 import { ToriFudaCardKeyboard } from './tori-fuda-card-keyboard';
 import { ToriFudaCardTouch } from './tori-fuda-card-touch';
 
-
 import type { NormalizedPrototype } from 'promidas/types';
 
 export type ToriFudaCardProps = {

--- a/src/components/token/token-manager-container.tsx
+++ b/src/components/token/token-manager-container.tsx
@@ -10,7 +10,6 @@ import type { ScreenSize } from '@/types/screen-size';
 
 import { TokenManagerPresentation } from './token-manager-presentation';
 
-
 interface TokenManagerContainerProps {
   screenSize: ScreenSize;
 }

--- a/src/lib/karuta/deck/deck-recipe-eto.ts
+++ b/src/lib/karuta/deck/deck-recipe-eto.ts
@@ -12,7 +12,6 @@ import type { DeckRecipe } from '@/models/karuta';
 import { ALL_PROTOTYPES } from './deck-recipe';
 import { createKeywordFilter } from './filter-factory';
 
-
 /**
  * Base configuration for ETO (Chinese zodiac) themed recipes
  * - Fetches all prototypes for filtering

--- a/src/lib/karuta/deck/deck-recipe-manager.ts
+++ b/src/lib/karuta/deck/deck-recipe-manager.ts
@@ -22,7 +22,6 @@ import { ETO_RECIPES } from './deck-recipe-eto';
 import { SAIJI_RECIPES } from './deck-recipe-saiji';
 import { createReleaseDateYearFilter } from './filter-factory';
 
-
 // ========================================
 // Section 0: Recipe Generation Helpers
 // ========================================

--- a/src/lib/karuta/deck/deck-recipe-saiji.ts
+++ b/src/lib/karuta/deck/deck-recipe-saiji.ts
@@ -11,7 +11,6 @@ import type { DeckRecipe } from '@/models/karuta';
 import { ALL_PROTOTYPES } from './deck-recipe';
 import { createKeywordFilter } from './filter-factory';
 
-
 /**
  * Annual events themed deck recipes (歳時記)
  */

--- a/src/lib/karuta/game/game-manager.test.ts
+++ b/src/lib/karuta/game/game-manager.test.ts
@@ -5,7 +5,6 @@ import type { Deck, Player, StackRecipe } from '@/models/karuta';
 import { GameManager } from './game-manager';
 import { StackManager } from '../stack/stack-manager';
 
-
 import type { PlayMode } from '../playMode/play-mode-manager';
 import type { NormalizedPrototype } from 'promidas/types';
 

--- a/src/lib/repository/dummy-repository.ts
+++ b/src/lib/repository/dummy-repository.ts
@@ -49,7 +49,6 @@ export class DummyRepository implements ProtopediaInMemoryRepository {
     throw new Error('Method not implemented.');
   }
   setupSnapshotFromSerializedData(
-     
     _data: SerializableSnapshot,
   ): SnapshotOperationResult {
     throw new Error('Method not implemented.');

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -20,7 +20,6 @@ import { promidasRepositoryManager } from '@/lib/repository/promidas-repository-
 import type { RepositoryState } from '@/lib/repository/promidas-repository-manager';
 import { getResponsiveStyles } from '@/lib/ui-utils';
 
-
 export const Route = createRootRoute({
   component: RootComponent,
 });


### PR DESCRIPTION
## Summary

Brings the repository into prettier compliance and fixes the two things that made running the formatter unsafe.

`npm run format:check` reported 21 files before this branch. It now passes cleanly.

## Why it had drifted

CI runs `npm run format` (auto-fix) rather than `npm run format:check` (`.github/workflows/ci.yml`). Unformatted code therefore never failed a build, and the auto-fixed result is discarded with the runner, so nothing ever pulled the tree back into line.

## What changed

| Commit | Content |
|---|---|
| `chore(format)` | Exclude the generated route tree from prettier |
| `docs(changelog)` | Wrap dependency globs in code spans |
| `style` | Apply prettier formatting |

### Excluding the generated route tree

`src/routeTree.gen.ts` is written by TanStack Router from the files in `src/routes/`, and says so itself:

```
// This file was automatically generated by TanStack Router.
// You should NOT make any changes in this file as it will be overwritten.
// Additionally, you should also exclude this file from your linter and/or
// formatter to prevent it from being checked or modified.
```

`eslint.config.mjs` already ignored it, but `.prettierignore` did not. Running the formatter rewrote 92 lines (adding semicolons throughout) that the next route change would regenerate away — a diff that would reappear indefinitely. Excluding it first is what makes the formatting commit stable.

### Protecting the changelog globs

`CHANGELOG.md` listed `@storybook/*, @tanstack/*, @testing-library/*`. Prettier's markdown parser reads the `*…*` span as emphasis and re-emits it with underscore delimiters, producing `@storybook/_, @tanstack/_` and losing the literal asterisks. Wrapping them in code spans keeps them intact, and is what they should have been anyway.

### The formatting itself

18 files, 18 deletions, zero insertions. Every one is a trailing blank line. No code changed — verified by inspecting the full diff: 17 empty-line removals and one whitespace-only line.

## Verification

- `npm run format:check` — passes for the first time (was 21 warnings)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 9 files, 216 tests passing
- `npm run build` — succeeds

## Follow-up worth considering

CI could switch from `npm run format` to `npm run format:check` now that the tree is clean. That would make future drift fail the build instead of being silently auto-fixed and discarded. Not included here, since it changes CI behaviour rather than formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
