### PR TITLE
fix(security): drop the VITE_ prefix from the API token variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,12 +6,16 @@
 # 3. Restart the dev server after changes
 
 # ------------------------------
-# ProtoPedia API client
+# ProtoPedia API token (scripts only)
 # ------------------------------
 
-# Access token for ProtoPedia API v2.
-# If unset or placeholder, client runs unauthenticated (reduced data/rate limits possible).
-VITE_PROTOPEDIA_API_V2_TOKEN=your_token_here
+# Access token for ProtoPedia API v2, read by `npm run generate-snapshot`.
+#
+# Deliberately without the VITE_ prefix. The app takes its token from the
+# in-app Token UI, not from here, and Vite serves every VITE_-prefixed
+# variable to the browser through import.meta.env - which would publish
+# this token to anyone who can reach the dev server.
+PROTOPEDIA_API_V2_TOKEN=your_token_here
 
 # ------------------------------
 # PROMIDAS

--- a/scripts/generate-snapshot.ts
+++ b/scripts/generate-snapshot.ts
@@ -10,7 +10,7 @@
  *   npm run generate-snapshot
  *
  * Environment:
- *   VITE_PROTOPEDIA_API_V2_TOKEN - Required API token
+ *   PROTOPEDIA_API_V2_TOKEN - Required API token
  *
  * Output:
  *   scripts/dev-snapshot-{timestamp}-{count}.json - Serialized snapshot data
@@ -124,7 +124,7 @@ async function main() {
 `);
 
   // Get API token from environment
-  const token = process.env.VITE_PROTOPEDIA_API_V2_TOKEN ?? 'no-token';
+  const token = process.env.PROTOPEDIA_API_V2_TOKEN ?? 'no-token';
 
   // Create repository
   console.log('⚙️ Creating repository...');


### PR DESCRIPTION
## Summary

Renames `VITE_PROTOPEDIA_API_V2_TOKEN` to `PROTOPEDIA_API_V2_TOKEN`.

The prefix caused the dev server to serve the real API token to the browser in plain text. Nothing reads the variable from client code any more, so the prefix has no purpose left.

## The problem

Vite exposes every `VITE_`-prefixed variable to the client, and the dev server embeds the entire `import.meta.env` object into any module that references it:

```
$ curl http://localhost:5173/pp-karuta/src/lib/logger.ts
import.meta.env = {"BASE_URL": "/pp-karuta/", ..., "VITE_PROTOPEDIA_API_V2_TOKEN": "<real token>", ...}
```

Three modules carried it: `src/lib/logger.ts`, `src/lib/karuta/deck/deck-manager.ts` and `src/lib/repository/promidas-repository-manager.ts`. Any of them returns the token to an unauthenticated `curl`. With `--host`, that is everyone on the same network.

Production builds were never affected: Vite inlines `import.meta.env.X` by static replacement, so a variable nothing references does not reach the bundle. Grepping `dist` for the token returns nothing.

## Why the prefix was there

It was correct when it was added. `src/lib/promidas.ts` read the token directly from client code:

```ts
const token = import.meta.env.VITE_PROTOPEDIA_API_V2_TOKEN;
```

`fc01226` deleted that file in December 2025, and `2a01c76` introduced the Token UI, which takes the token from an input field and keeps it in `sessionStorage`. The reference disappeared; the prefix stayed.

## Why it is safe to drop

| Consumer | Reads it how | Needs the prefix |
|---|---|---|
| App (browser) | Token UI → `sessionStorage` | No — never reads the variable |
| `npm run generate-snapshot` | `process.env` via `dotenv` | No — `dotenv` does not filter by prefix |

Confirmed by cross-referencing all eight variables in `.env.example` against every `import.meta.env` reference in `src/`. Seven are read by client code and keep their prefix. The token is the only one with zero references — and the only one whose value is a secret.

The unprefixed name also matches the promidas libraries: `TOKEN_KEYS.PROTOPEDIA_API_V2_TOKEN` resolves to `'PROTOPEDIA_API_V2_TOKEN'`, and `promidas`'s own docs name the same variable.

## What changed

| File | Change |
|---|---|
| `.env.example` | Renamed, and the comment now states why the prefix must not come back |
| `scripts/generate-snapshot.ts` | `process.env` reference and the JSDoc environment note |

`.env.test` needed no change — it holds only log and debug flags, no token. `.env.local` is untracked and must be renamed by hand; without that, `generate-snapshot` falls back to `'no-token'`.

## Verification

Keys injected into `import.meta.env`, before and after:

```diff
  BASE_URL, DEV, MODE, PROD, SSR,
  VITE_DEBUG_MODE, VITE_DEV_SNAPSHOT_PATH, VITE_LOG_LEVEL, VITE_PROMIDAS_LOG_LEVEL,
- VITE_PROTOPEDIA_API_V2_TOKEN,
  VITE_RANDOM_YOMIFUDA, VITE_UI_DEBUG, VITE_USE_DEV_SNAPSHOT
```

Every served module was then grepped for the token value: three matched before, none match now. `typecheck`, `lint` and `format:check` are clean.

Two behaviours were proven rather than assumed: `dotenv` reads unprefixed names (a probe env file with both forms resolved both), and Vite withholds unprefixed variables from the client (an unprefixed probe variable never appeared in `import.meta.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
