### PR TITLE
fix(storybook): exclude VitePWA from the Storybook build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,14 +16,37 @@ const config: StorybookConfig = {
     reactDocgen: 'react-docgen-typescript',
   },
   async viteFinal(config) {
-    return mergeConfig(config, {
-      plugins: [tailwindcss()],
-      resolve: {
-        alias: {
-          '@': path.resolve(__dirname, '../src'),
+    return mergeConfig(
+      {
+        ...config,
+        // Storybook loads the project's vite.config.ts, so VitePWA ends up
+        // registered here too. Storybook needs no service worker, and its
+        // manager bundle (sb-manager/globals-runtime.js, ~3.25 MB) exceeds
+        // workbox.maximumFileSizeToCacheInBytes, which vite-plugin-pwa
+        // reports as a build failure rather than a warning. Dropping the
+        // plugins keeps that limit meaningful for the app build instead of
+        // having to raise it for Storybook's sake.
+        plugins: (config.plugins ?? [])
+          .flat(Infinity)
+          .filter(
+            (plugin) =>
+              !(
+                plugin &&
+                typeof plugin === 'object' &&
+                'name' in plugin &&
+                String(plugin.name).startsWith('vite-plugin-pwa')
+              ),
+          ),
+      },
+      {
+        plugins: [tailwindcss()],
+        resolve: {
+          alias: {
+            '@': path.resolve(__dirname, '../src'),
+          },
         },
       },
-    });
+    );
   },
 };
 export default config;


### PR DESCRIPTION
## Summary

`npm run build-storybook` fails on `main`. This excludes VitePWA from the Storybook build, which is the root cause.

## Why it fails

Three things combine.

**1. Storybook inherits the app's Vite plugins.** `@storybook/react-vite` loads the project's `vite.config.ts`, so all five plugins that `VitePWA()` registers are active during the Storybook build too:

```
vite-plugin-pwa
vite-plugin-pwa:info
vite-plugin-pwa:build      ← generates the service worker
vite-plugin-pwa:dev-sw
vite-plugin-pwa:pwa-assets
```

**2. Storybook's manager bundle is larger than the precache limit.** `sb-manager/globals-runtime.js` is 3.25 MB against the 3 MB configured in `vite.config.ts`.

**3. vite-plugin-pwa turns that into a build failure.** workbox itself only warns that the asset will not be precached. The promotion to an error happens here:

```js
// vite-plugin-pwa/dist/chunk-G4TAN34B.js:39
function logWorkboxResult(version, throwMaximumFileSizeToCacheInBytes, ...) {
  if (throwMaximumFileSizeToCacheInBytes) {
    const entries = buildResult.warnings.filter((w) => w.includes("maximumFileSizeToCacheInBytes"));
    if (entries.length) {
      throw new Error(...)
```

driven by a default that opts into throwing:

```js
// index.js:815
showMaximumFileSizeToCacheInBytesWarning = false
// index.js:965
throwMaximumFileSizeToCacheInBytes: !showMaximumFileSizeToCacheInBytesWarning   // → true
```

### A misleading detail

The error says *"Configure `workbox.maximumFileSizeToCacheInBytes` to change the limit: the default value is 2 MiB"*. That sentence is hardcoded and does not read the configured value, so it looks as though the `3 * 1024 * 1024` in `vite.config.ts:209` is being ignored. It is not — the setting applies, and 3.25 MB simply exceeds 3 MB.

## The fix

Filter the PWA plugins out in `viteFinal`. Storybook has no use for a service worker.

The alternatives were rejected because they let Storybook dictate the app's configuration:

| Alternative | Why not |
|---|---|
| Raise `maximumFileSizeToCacheInBytes` past 3.25 MB | The app's precache budget would answer to Storybook's bundle size, and would break again as Storybook grows |
| Add `sb-manager/**` to `globIgnores` | Same coupling, expressed in the app's config |
| Set `showMaximumFileSizeToCacheInBytesWarning: true` | Silences the check for the app build too, where an asset dropping out of the precache manifest is worth knowing about |

## Verification

| Check | Before | After |
|---|---|---|
| `npm run build-storybook` | fails | **succeeds** |
| `sw.js` / `manifest.webmanifest` / `registerSW.js` in `storybook-static/` | n/a | none — plugins correctly excluded |
| CSP meta in `storybook-static/*.html` | n/a | none |
| `npm run build` → PWA artefacts | ok | ok — all three emitted, 24 precache entries |
| `npm run build` → CSP meta | ok | ok — still first in `<head>` |
| `storybook dev` (`index.html`, `iframe.html`) | ok | ok — both HTTP 200 |

`typecheck`, `lint`, `format:check` clean; `npm test` passes 216 tests.

## Note on CI

CI never ran `build-storybook` (`ci.yml` runs `format`, `lint`, `test`, `build`), so this failure was invisible there and only affected local static builds. `storybook dev` was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
