### PR TITLE
ci: verify formatting instead of auto-fixing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
         # run: npm --loglevel debug list
         # run: npm --loglevel silly list
 
-      # - name: Run format check
-      #   run: npm run format:check
-      - name: Run format check and auto-fix
-        run: npm run format
+      # Verify formatting rather than auto-fixing it: `npm run format`
+      # rewrites files and exits 0, so unformatted code passed CI and the
+      # corrected files were discarded with the runner.
+      - name: Run format check
+        run: npm run format:check
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
## Summary

CI never verified formatting. This makes it do so.

## What was happening

The format step ran `npm run format`, which is `prettier --write`:

```yaml
      # - name: Run format check
      #   run: npm run format:check
      - name: Run format check and auto-fix
        run: npm run format
```

`--write` is not a verification command. It rewrites offending files and exits 0. So every CI run did this:

1. Check out the repository
2. Find the unformatted files
3. Format all of them
4. Exit 0 and move on
5. End the job — **the corrected files vanish with the runner**

Nothing was committed, nothing was pushed. The next run repeated the same work on the same files. The step name saying "format check" made it read as though something was being validated.

This has been the case since `9a174e6` added CI in December 2025, with the `format:check` variant commented out directly above it from the start.

## The drift it allowed

`npm run format:check` reported **21 files** before `de5a3c2` brought the tree back into compliance. That is what eight months of a check that cannot fail looks like.

## Verification

A formatting violation was introduced deliberately (trailing whitespace in `src/lib/logger.ts`) and both commands were run against it:

| Command | Behaviour | Exit code |
|---|---|---|
| `npm run format:check` (new) | reports `[warn] src/lib/logger.ts` | **1 — CI fails** |
| `npm run format` (old) | silently rewrites the file | **0 — CI passes** |

The current `main` passes `format:check`, so this does not fail on existing code.

## Note

The replacement carries a comment explaining why, so the reasoning survives if someone considers switching back:

```yaml
      # Verify formatting rather than auto-fixing it: `npm run format`
      # rewrites files and exits 0, so unformatted code passed CI and the
      # corrected files were discarded with the runner.
      - name: Run format check
        run: npm run format:check
```

If auto-fixing is preferred over failing, that needs a step which actually commits the result — otherwise it is equivalent to doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
