### PR TITLE
chore(release): 2026.08.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+## [2026.08.24] - 2026-08-24
+
+### Changed
+
+- Apply prettier formatting across the repository. The tree had drifted because
+  CI ran the auto-fixing `npm run format` and discarded its result.
+- Exclude the generated `src/routeTree.gen.ts` from prettier. TanStack Router
+  overwrites it on every route change, and the file itself asks to be excluded
+  from linters and formatters.
+- CI now verifies formatting with `npm run format:check` instead of running
+  `npm run format`, which rewrote files and exited 0 without ever failing.
+
+### Fixed
+
+- `npm run build-storybook` no longer fails. Storybook inherited VitePWA from
+  the project's Vite config, and its manager bundle exceeded the workbox
+  precache limit, which vite-plugin-pwa reports as a build error rather than a
+  warning.
+
+### Security
+
+- Add a Content Security Policy. Production delivers it through a
+  `<meta http-equiv>` tag injected at build time, since GitHub Pages cannot set
+  response headers; the dev server delivers the same policy as a response
+  header. `connect-src` limits the destinations the API token can reach to
+  `protopedia.net` alone, which downgrades silent, unlimited exfiltration to a
+  single visible page navigation.
+- Drop the `VITE_` prefix from the ProtoPedia API token variable
+  (`VITE_PROTOPEDIA_API_V2_TOKEN` → `PROTOPEDIA_API_V2_TOKEN`). Vite exposes
+  every `VITE_`-prefixed variable to the browser, and the dev server embedded
+  the whole `import.meta.env` object into any module that read it, serving the
+  token in plain text. No client code had read the variable since the Token UI
+  replaced it; only `npm run generate-snapshot` uses it, through `process.env`.
+
+## [2026.07.21] - 2026-07-21
+
 ### Added
 
 - Intro page: add a ProtoPedia data source / CC BY 4.0 attribution line below
@@ -17,6 +53,8 @@ and this project adheres to [CalVer](https://calver.org/).
   ProtoPedia data retrieved through the ProtoPedia API (v2), and that ProtoPedia
   applies the CC BY 4.0 license to registered work information by default
   (English and Japanese).
+- Design: add Pencil design files (`pp-karuta.pen`, `pp-karuta-ds.pen`) covering
+  the design system and screen mockups.
 
 ## [2026.01.28] - 2026-01-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pp-karuta",
-  "version": "2026.07.21",
+  "version": "2026.08.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pp-karuta",
-      "version": "2026.07.21",
+      "version": "2026.08.24",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pp-karuta",
-  "version": "2026.07.21",
+  "version": "2026.08.24",
   "type": "module",
   "description": "ppk",
   "engines": {


### PR DESCRIPTION
## Summary

Bumps the version to `2026.08.24` and brings the changelog back in line with what has actually shipped.

## What changed

| Commit | Content |
|---|---|
| `docs(changelog)` | Record 2026.08.24, and add the missing 2026.07.21 section |
| `chore(release)` | `package.json` / `package-lock.json` → `2026.08.24` |

### The missing 2026.07.21 section

The changelog jumped straight from `[2026.01.28]` to `[Unreleased]`, even though `2026.07.21` shipped in July. Its release commit (`fbf2c45`) touched only `package.json` and `package-lock.json`, so the entries describing that release were never moved out of `[Unreleased]` and have been sitting there looking unreleased ever since.

Checking the range confirms what belongs there. Between `3f7a78e` (2026.01.28) and `fbf2c45` (2026.07.21) there are exactly two substantive commits:

- `2bd9580 docs: add ProtoPedia CC BY 4.0 attribution (intro page + README)` — this is precisely what `[Unreleased]` described
- `e6a4c36 docs(design): add Pencil design files with design system and screen mockups`

Both are now listed under `## [2026.07.21] - 2026-07-21`.

Cross-referencing every shipped version against the changelog shows this was the only gap: 2026.01.28, 2026.01.16, 2026.01.14, 2026.01.09 and 2026.01.08 all have their sections.

### The 2026.08.24 section

Covers this cycle, grouped per Keep a Changelog:

- **Security** — the Content Security Policy (#56) and the `VITE_` prefix removal (#58)
- **Fixed** — `build-storybook` (#59)
- **Changed** — the prettier pass and generated-file exclusion (#57), and the CI format check (#60)

## A note on `npm version`

`npm version 2026.08.24` writes `2026.8.24`, because semver rejects leading zeros. Every earlier release here is zero-padded (`2026.07.21`, `2026.01.09`), so the value has to be corrected by hand in both `package.json` and `package-lock.json` — three occurrences in total.

## Verification

`format:check`, `lint`, `typecheck` clean; `npm test` passes 216 tests; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
